### PR TITLE
Set export options correctly after import | Rename color attributes

### DIFF
--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -169,12 +169,12 @@ class dff_importer:
 
             # Add Vertex Colors
             if geom.flags & dff.rpGEOMETRYPRELIT:
-                vertex_color = bm.loops.layers.color.new()
+                vertex_color = bm.loops.layers.color.new('Day')
                 mesh['dragon_day_cols'] = True
 
             extra_vertex_color = None
             if 'extra_vert_color' in geom.extensions:
-                extra_vertex_color = bm.loops.layers.color.new()
+                extra_vertex_color = bm.loops.layers.color.new('Night')
                 mesh['dragon_night_cols'] = True
 
             if dff_importer.use_mat_split and 'mat_split' in geom.extensions:

--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -123,9 +123,14 @@ class dff_importer:
             mesh['dragon_normals'] = False
             mesh['dragon_pipeline'] = 'NONE'
             mesh['dragon_cust_pipeline'] = None
+            mesh['dragon_binsplit'] = (geom.flags & dff.rpGEOMETRYTRISTRIP) != 0
             mesh['dragon_light'] = (geom.flags & dff.rpGEOMETRYLIGHT) != 0
             mesh['dragon_modulate_color'] = \
                 (geom.flags & dff.rpGEOMETRYMODULATEMATERIALCOLOR) != 0
+            mesh['dragon_day_cols'] = False
+            mesh['dragon_night_cols'] = False
+            mesh['dragon_uv_map1'] = False
+            mesh['dragon_uv_map2'] = False
 
             uv_layers = []
             
@@ -155,14 +160,22 @@ class dff_importer:
             # Add UV Layers
             for layer in geom.uv_layers:
                 uv_layers.append(bm.loops.layers.uv.new())
-                
+
+                if len(geom.uv_layers) > 0:
+                    mesh['dragon_uv_map1'] = True
+                    if len(geom.uv_layers) > 1:
+                        mesh['dragon_uv_map2'] = True
+
+
             # Add Vertex Colors
             if geom.flags & dff.rpGEOMETRYPRELIT:
                 vertex_color = bm.loops.layers.color.new()
+                mesh['dragon_day_cols'] = True
 
             extra_vertex_color = None
             if 'extra_vert_color' in geom.extensions:
                 extra_vertex_color = bm.loops.layers.color.new()
+                mesh['dragon_night_cols'] = True
 
             if dff_importer.use_mat_split and 'mat_split' in geom.extensions:
                 faces = geom.extensions['mat_split']
@@ -685,20 +698,30 @@ class dff_importer:
 
                 else:
                     # Set object properties from mesh properties
-                    obj.dff.pipeline       = mesh['dragon_pipeline']
-                    obj.dff.export_normals = mesh['dragon_normals']
-                    obj.dff.light          = mesh['dragon_light']
-                    obj.dff.modulate_color = mesh['dragon_modulate_color']
+                    obj.dff.pipeline        = mesh['dragon_pipeline']
+                    obj.dff.export_normals  = mesh['dragon_normals']
+                    obj.dff.export_binsplit = mesh['dragon_binsplit']
+                    obj.dff.light           = mesh['dragon_light']
+                    obj.dff.modulate_color  = mesh['dragon_modulate_color']
+                    obj.dff.day_cols        = mesh['dragon_day_cols']
+                    obj.dff.night_cols      = mesh['dragon_night_cols']
+                    obj.dff.uv_map1         = mesh['dragon_uv_map1']
+                    obj.dff.uv_map2         = mesh['dragon_uv_map2']
 
                     if obj.dff.pipeline == 'CUSTOM':
                         obj.dff.custom_pipeline = mesh['dragon_cust_pipeline']
                     
                     # Delete temporary properties used earlier
-                    del mesh['dragon_pipeline'      ]
-                    del mesh['dragon_normals'       ]
-                    del mesh['dragon_cust_pipeline' ]
-                    del mesh['dragon_light'         ]
+                    del mesh['dragon_pipeline']
+                    del mesh['dragon_normals']
+                    del mesh['dragon_binsplit']
+                    del mesh['dragon_cust_pipeline']
+                    del mesh['dragon_light']
                     del mesh['dragon_modulate_color']
+                    del mesh['dragon_day_cols']
+                    del mesh['dragon_night_cols']
+                    del mesh['dragon_uv_map1']
+                    del mesh['dragon_uv_map2']
                     
                 # Set vertex groups
                 if index in self.skin_data:


### PR DESCRIPTION
Right now this export options always checked by default and not based on the model's properties.