### PR TITLE
Clamp Vertex Colors (fix exception)

### DIFF
--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -581,7 +581,8 @@ class dff_exporter:
     @staticmethod
     def convert_slinear_to_srgb (col):
         color = mathutils.Color (col[:3])
-        return tuple(color.from_scene_linear_to_srgb ()) + (col[3],)
+        color_srgb = color.from_scene_linear_to_srgb()
+        return tuple(max(0, min(1, channel)) for channel in color_srgb) + (col[3],)  # Including alpha unchanged
 
     #######################################################
     @staticmethod


### PR DESCRIPTION
Hey thank you so much for this incredible project !! 😄 I love that the SA community is still going strong.

I encountered an exception when trying to export vertex colours from Cycles baked vertex lighting.

![image](https://github.com/Parik27/DragonFF/assets/4960696/35bda323-c1fc-4cdb-b133-c7bca0b7e2b8)

It seems the vertex colours can go out-of-gamut, so it'd be trying to write RGB values like `(263, 100, 100)` which causes an exception when packing.

I think the best way would be to gamut map or tonemap the sRGB colours, but IMO that starts adding stylistic choices to DragonFF so I went with a simple clamp 😁 WDYT?

![vert-colors-gtasa-2](https://github.com/Parik27/DragonFF/assets/4960696/1002af69-8ffb-4a56-9a62-eaffc6db6f9a)
