### PR TITLE
Added Triangle Strip option for export Bin Mesh PLG

### DIFF
--- a/gtaLib/pyffi/utils/trianglemesh.py
+++ b/gtaLib/pyffi/utils/trianglemesh.py
@@ -1,0 +1,344 @@
+# ***** BEGIN LICENSE BLOCK *****
+#
+# Copyright (c) 2007-2012, Python File Format Interface
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#    * Neither the name of the Python File Format Interface
+#      project nor the names of its contributors may be used to endorse
+#      or promote products derived from this software without specific
+#      prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ***** END LICENSE BLOCK *****
+
+# modified from:
+
+# http://techgame.net/projects/Runeblade/browser/trunk/RBRapier/RBRapier/Tools/Geometry/Analysis/TriangleMesh.py?rev=760
+
+# original license:
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~ License
+# ~
+# - The RuneBlade Foundation library is intended to ease some
+# - aspects of writing intricate Jabber, XML, and User Interface (wxPython, etc.)
+# - applications, while providing the flexibility to modularly change the
+# - architecture. Enjoy.
+# ~
+# ~ Copyright (C) 2002  TechGame Networks, LLC.
+# ~
+# ~ This library is free software; you can redistribute it and/or
+# ~ modify it under the terms of the BSD style License as found in the
+# ~ LICENSE file included with this distribution.
+# ~
+# ~ TechGame Networks, LLC can be reached at:
+# ~ 3578 E. Hartsel Drive #211
+# ~ Colorado Springs, Colorado, USA, 80920
+# ~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~ Imports
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import operator # itemgetter
+from weakref import WeakSet
+
+
+class Edge:
+    """A directed edge which keeps track of its faces."""
+
+    def __init__(self, ev0, ev1):
+        """Edge constructor.
+
+        >>> edge = Edge(6, 9)
+        >>> edge.verts
+        (6, 9)
+        """
+        
+        if ev0 == ev1:
+            raise ValueError("Degenerate edge.")
+
+        self.verts = (ev0, ev1)
+        """Vertices of the edge."""
+
+        self.faces = WeakSet()
+        """Weak set of faces that have this edge."""
+
+    def __repr__(self):
+        """String representation.
+
+        >>> Edge(1, 2)
+        Edge(1, 2)
+        """
+        return "Edge(%s, %s)" % self.verts
+
+class Face:
+    """An oriented face which keeps track its adjacent faces."""
+
+    def __init__(self, v0, v1, v2):
+        """Construct face from vertices.
+
+        >>> face = Face(3, 7, 5)
+        >>> face.verts
+        (3, 7, 5)
+        >>> Face(30, 0, 30) # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        ValueError: ...
+        """
+        if v0 == v1 or v1 == v2 or v2 == v0:
+            raise ValueError("Degenerate face.")
+        if v0 < v1 and v0 < v2:
+            self.verts = (v0, v1, v2)
+        if v1 < v0 and v1 < v2:
+            self.verts = (v1, v2, v0)
+        if v2 < v0 and v2 < v1:
+            self.verts = (v2, v0, v1)
+        # no index yet
+        self.index = None
+
+        self.adjacent_faces = (WeakSet(), WeakSet(), WeakSet())
+        """Weak sets of adjacent faces along edge opposite each vertex."""
+
+    def __repr__(self):
+        """String representation.
+
+        >>> Face(3, 1, 2)
+        Face(1, 2, 3)
+        """
+        return "Face(%s, %s, %s)" % self.verts
+
+    def __eq__(self, other):
+        """
+        :param other:
+        :return:
+        """
+        return (self.verts[0] == other.verts[0]) & (self.verts[1] == self.verts[1]) & (self.verts[2] == self.verts[2])
+
+    def __hash__(self):
+        return self.verts[0] + self.verts[1] + self.verts[2]
+
+    def get_next_vertex(self, vi):
+        """Get next vertex of face.
+
+        >>> face = Face(8, 7, 5)
+        >>> face.get_next_vertex(8)
+        7
+        """
+        # XXX using list(self.verts) instead of self.verts
+        # XXX for Python 2.5 compatibility
+        return self.verts[(1, 2, 0)[list(self.verts).index(vi)]]
+
+    def get_adjacent_faces(self, vi):
+        """Get adjacent faces associated with the edge opposite a vertex."""
+        # XXX using list(self.verts) instead of self.verts
+        # XXX for Python 2.5 compatibility
+        return self.adjacent_faces[list(self.verts).index(vi)]
+
+
+class Mesh:
+    """A mesh of interconnected faces.
+
+    :ivar faces: List of faces of the mesh.
+    :type faces: ``list`` of :class:`Face`"""
+    def __init__(self, faces=None, lock=True):
+        """Initialize a mesh, and optionally assign its faces and lock.
+
+        :param faces: ``None``, or an iterator over faces to assign to
+            the mesh.
+        :type faces: ``Iterable`` or ``type(None)``
+        :param lock: Whether to lock the mesh or not (ignored when
+            `faces` are not specified).
+        :type lock: ``bool``
+        """
+        self._faces = {}
+        """Dictionary of all faces."""
+
+        self._edges = {}
+        """Dictionary of all edges."""
+
+        if faces is not None:
+            for v0, v1, v2 in faces:
+                self.add_face(v0, v1, v2)
+            if lock:
+                self.lock()
+
+    def __repr__(self):
+        """String representation. Examples:
+
+        >>> m = Mesh()
+        >>> m
+        Mesh()
+        >>> tmp = m.add_face(1, 2, 3)
+        >>> tmp = m.add_face(3, 2, 4)
+        >>> m
+        Mesh(faces=[(1, 2, 3), (2, 4, 3)], lock=False)
+        >>> m.lock()
+        >>> m
+        Mesh(faces=[(1, 2, 3), (2, 4, 3)])
+        >>> Mesh(faces=[(1, 2, 3),(3, 2, 4)])
+        Mesh(faces=[(1, 2, 3), (2, 4, 3)])
+        """
+        try:
+            self.faces
+        except AttributeError:
+            # unlocked
+            if not self._faces:
+                # special case
+                return "Mesh()"
+            return ("Mesh(faces=[%s], lock=False)"
+                    % ', '.join(repr(faceverts)
+                                for faceverts in sorted(self._faces)))
+        else:
+            # locked
+            return ("Mesh(faces=[%s])"
+                    % ', '.join(repr(face.verts)
+                                for face in self.faces))
+
+    def _add_edge(self, face, pv0, pv1):
+        """Create new edge for mesh for given face, or return existing
+        edge. Lists of faces of the new/existing edge is also updated,
+        as well as lists of adjacent faces. For internal use only,
+        called on each edge of the face in add_face.
+        """
+        # create edge if not found
+        try:
+            edge = self._edges[(pv0, pv1)]
+        except KeyError:
+            # create edge
+            edge = Edge(pv0, pv1)
+            self._edges[(pv0, pv1)] = edge
+
+        # update edge's faces
+        edge.faces.add(face)
+
+        # find reverse edge in mesh
+        try:
+            otheredge = self._edges[(pv1, pv0)]
+        except KeyError:
+            pass
+        else:
+            # update adjacent faces
+            pv2 = face.get_next_vertex(pv1)
+            for otherface in otheredge.faces:
+                otherpv2 = otherface.get_next_vertex(pv0)
+                face.get_adjacent_faces(pv2).add(otherface)
+                otherface.get_adjacent_faces(otherpv2).add(face)
+
+    def add_face(self, v0, v1, v2):
+        """Create new face for mesh, or return existing face. List of
+        adjacent faces is also updated.
+
+        >>> m = Mesh()
+        >>> f0 = m.add_face(0, 1, 2)
+        >>> [list(faces) for faces in f0.adjacent_faces]
+        [[], [], []]
+
+        >>> m = Mesh()
+        >>> f0 = m.add_face(0, 1, 2)
+        >>> f1 = m.add_face(2, 1, 3)
+        >>> f2 = m.add_face(2, 3, 4)
+        >>> len(m._faces)
+        3
+        >>> len(m._edges)
+        9
+
+
+        """
+        face = Face(v0, v1, v2)
+        try:
+            face = self._faces[face.verts]
+        except KeyError:
+            # create edges and update links between faces
+            self._add_edge(face, v0, v1)
+            self._add_edge(face, v1, v2)
+            self._add_edge(face, v2, v0)
+            # register face in mesh
+            self._faces[face.verts] = face
+
+        return face
+
+    def lock(self):
+        """Lock the mesh. Frees memory by clearing the structures
+        which are only used to update the face adjacency lists. Sets
+        the faces attribute to the sorted list of all faces (sorting helps
+        with ensuring that the strips in faces are close together).
+
+        >>> m = Mesh()
+        >>> f0 = m.add_face(3, 1, 2)
+        >>> f1 = m.add_face(0, 1, 2)
+        >>> m.faces # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        AttributeError: ...
+        >>> m.lock()
+        >>> m.faces # should be sorted
+        [Face(0, 1, 2), Face(1, 2, 3)]
+        >>> m.faces[0].index
+        0
+        >>> m.faces[1].index
+        1
+        """
+        # store faces and set their index
+        self.faces = []
+        for i, (verts, face) in enumerate(sorted(iter(self._faces.items()),
+                                          key=operator.itemgetter(0))):
+            face.index = i
+            self.faces.append(face)
+        # remove helper structures
+        del self._faces
+        del self._edges
+
+    def discard_face(self, face):
+        """Remove the face from the mesh.
+
+        >>> m = Mesh()
+        >>> f0 = m.add_face(0, 1, 2)
+        >>> f1 = m.add_face(1, 3, 2)
+        >>> f2 = m.add_face(2, 3, 4)
+        >>> m.lock()
+        >>> list(f0.get_adjacent_faces(0))
+        [Face(1, 3, 2)]
+        >>> m.discard_face(f1)
+        >>> list(f0.get_adjacent_faces(0))
+        []
+        """
+        # note: don't delete, but set to None, to ensure that other
+        # face indices remain valid
+        self.faces[face.index] = None
+        for adj_faces in face.adjacent_faces:
+            for adj_face in adj_faces:
+                for adj_adj_faces in adj_face.adjacent_faces:
+                    adj_adj_faces.discard(face)
+                    # faster (but breaks py3k!!):
+                    #if id(face) in adj_adj_faces.data:
+                    #    del adj_adj_faces.data[id(face)]
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/gtaLib/pyffi/utils/trianglestripifier.py
+++ b/gtaLib/pyffi/utils/trianglestripifier.py
@@ -1,0 +1,548 @@
+"""A general purpose stripifier, based on NvTriStrip (http://developer.nvidia.com/)
+
+Credit for porting NvTriStrip to Python goes to the RuneBlade Foundation
+library:
+http://techgame.net/projects/Runeblade/browser/trunk/RBRapier/RBRapier/Tools/Geometry/Analysis/TriangleStripifier.py?rev=760
+
+The algorithm of this stripifier is an improved version of the RuneBlade
+Foundation / NVidia stripifier; it makes no assumptions about the
+underlying geometry whatsoever and is intended to produce valid
+output in all circumstances.
+"""
+
+# ***** BEGIN LICENSE BLOCK *****
+#
+# Copyright (c) 2007-2012, Python File Format Interface
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#    * Neither the name of the Python File Format Interface
+#      project nor the names of its contributors may be used to endorse
+#      or promote products derived from this software without specific
+#      prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ***** END LICENSE BLOCK *****
+
+import itertools
+import random # choice
+
+from .trianglemesh import Face, Mesh
+
+class TriangleStrip(object):
+    """A heavily specialized oriented strip of faces.
+
+    Heavily adapted from NvTriStrip and RuneBlade. Originals can be found at
+    http://developer.nvidia.com/view.asp?IO=nvtristrip_library
+    and
+    http://techgame.net/projects/Runeblade/browser/trunk/RBRapier/RBRapier/Tools/Geometry/Analysis/TriangleStripifier.py?rev=760
+    """
+
+    def __init__(self, stripped_faces=None,
+                 faces=None, vertices=None, reversed_=False):
+        """Initialise the triangle strip."""
+        self.faces = faces if faces is not None else []
+        self.vertices = vertices if vertices is not None else []
+        self.reversed_ = reversed_
+
+        # set of indices of stripped faces
+        self.stripped_faces = (stripped_faces
+                               if stripped_faces is not None else set())
+
+    def __repr__(self):
+        return ("TriangleStrip(stripped_faces=%s, faces=%s, vertices=%s, reversed_=%s)"
+                % (repr(self.stripped_faces), repr(self.faces),
+                   repr(self.vertices), repr(self.reversed_)))
+
+    def get_unstripped_adjacent_face(self, face, vi):
+        """Get adjacent face which is not yet stripped."""
+        for otherface in face.get_adjacent_faces(vi):
+            if otherface.index not in self.stripped_faces:
+                return otherface
+
+    def traverse_faces(self, start_vertex, start_face, forward):
+        """Builds a strip traveral of faces starting from the
+        start_face and the edge opposite start_vertex. Returns number
+        of faces added.
+        """
+        count = 0
+        pv0 = start_vertex
+        pv1 = start_face.get_next_vertex(pv0)
+        pv2 = start_face.get_next_vertex(pv1)
+        next_face = self.get_unstripped_adjacent_face(start_face, pv0)
+        while next_face:
+            self.stripped_faces.add(next_face.index)
+            count += 1
+            if count & 1:
+                if forward:
+                    pv0 = pv1
+                    pv1 = next_face.get_next_vertex(pv0)
+                    self.vertices.append(pv1)
+                    self.faces.append(next_face)
+                else:
+                    pv0 = pv2
+                    pv2 = next_face.get_next_vertex(pv1)
+                    self.vertices.insert(0, pv2)
+                    self.faces.insert(0, next_face)
+                    self.reversed_ = not self.reversed_
+            else:
+                if forward:
+                    pv0 = pv2
+                    pv2 = next_face.get_next_vertex(pv1)
+                    self.vertices.append(pv2)
+                    self.faces.append(next_face)
+                else:
+                    pv0 = pv1
+                    pv1 = next_face.get_next_vertex(pv0)
+                    self.vertices.insert(0, pv1)
+                    self.faces.insert(0, next_face)
+                    self.reversed_ = not self.reversed_
+            next_face = self.get_unstripped_adjacent_face(next_face, pv0)
+        return count
+
+    def build(self, start_vertex, start_face):
+        """Builds the face strip forwards, then backwards. Returns
+        index of start_face.
+
+        Check case of single triangle
+        -----------------------------
+
+        >>> m = Mesh()
+        >>> face = m.add_face(0, 1, 2)
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(0, face)
+        0
+        >>> t
+        TriangleStrip(stripped_faces={0}, faces=[Face(0, 1, 2)], vertices=[0, 1, 2], reversed_=False)
+        >>> t.get_strip()
+        [0, 1, 2]
+        >>> t = TriangleStrip()
+        >>> t.build(1, face)
+        0
+        >>> t
+        TriangleStrip(stripped_faces={0}, faces=[Face(0, 1, 2)], vertices=[1, 2, 0], reversed_=False)
+        >>> t.get_strip()
+        [1, 2, 0]
+        >>> t = TriangleStrip()
+        >>> t.build(2, face)
+        0
+        >>> t
+        TriangleStrip(stripped_faces={0}, faces=[Face(0, 1, 2)], vertices=[2, 0, 1], reversed_=False)
+        >>> t.get_strip()
+        [2, 0, 1]
+
+        Check case of two triangles, with special strip winding fix
+        -----------------------------------------------------------
+
+        >>> m = Mesh()
+        >>> face0 = m.add_face(0, 1, 2)
+        >>> face1 = m.add_face(2, 1, 3)
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(0, face0)
+        0
+        >>> t
+        TriangleStrip(stripped_faces={0, 1}, faces=[Face(0, 1, 2), Face(1, 3, 2)], vertices=[0, 1, 2, 3], reversed_=False)
+        >>> t.get_strip()
+        [0, 1, 2, 3]
+        >>> t = TriangleStrip()
+        >>> t.build(1, face0)
+        1
+        >>> t
+        TriangleStrip(stripped_faces={0, 1}, faces=[Face(1, 3, 2), Face(0, 1, 2)], vertices=[3, 1, 2, 0], reversed_=True)
+        >>> t.get_strip()
+        [3, 2, 1, 0]
+        >>> t = TriangleStrip()
+        >>> t.build(2, face1)
+        1
+        >>> t
+        TriangleStrip(stripped_faces={0, 1}, faces=[Face(0, 1, 2), Face(1, 3, 2)], vertices=[0, 2, 1, 3], reversed_=True)
+        >>> t.get_strip()
+        [0, 1, 2, 3]
+        >>> t = TriangleStrip()
+        >>> t.build(3, face1)
+        0
+        >>> t
+        TriangleStrip(stripped_faces={0, 1}, faces=[Face(1, 3, 2), Face(0, 1, 2)], vertices=[3, 2, 1, 0], reversed_=False)
+        >>> t.get_strip()
+        [3, 2, 1, 0]
+
+        Check that extra vertex is appended to fix winding
+        --------------------------------------------------
+
+        >>> m = Mesh()
+        >>> face0 = m.add_face(1, 3, 2)
+        >>> face1 = m.add_face(2, 3, 4)
+        >>> face2 = m.add_face(4, 3, 5)
+        >>> face3 = m.add_face(4, 5, 6)
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(2, face1)
+        1
+        >>> t
+        TriangleStrip(stripped_faces={0, 1, 2, 3}, faces=[Face(1, 3, 2), Face(2, 3, 4), Face(3, 5, 4), Face(4, 5, 6)], vertices=[1, 2, 3, 4, 5, 6], reversed_=True)
+        >>> t.get_strip()
+        [1, 1, 2, 3, 4, 5, 6]
+
+        Check that strip is reversed to fix winding
+        -------------------------------------------
+
+        >>> m = Mesh()
+        >>> face0 = m.add_face(1, 3, 2)
+        >>> face1 = m.add_face(2, 3, 4)
+        >>> face2 = m.add_face(4, 3, 5)
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(2, face1)
+        1
+        >>> t
+        TriangleStrip(stripped_faces={0, 1, 2}, faces=[Face(1, 3, 2), Face(2, 3, 4), Face(3, 5, 4)], vertices=[1, 2, 3, 4, 5], reversed_=True)
+        >>> t.get_strip()
+        [5, 4, 3, 2, 1]
+
+        More complicated mesh
+        ---------------------
+
+        >>> m = Mesh()
+        >>> face0 = m.add_face(0, 1, 2)
+        >>> face1 = m.add_face(2, 1, 7)
+        >>> face2 = m.add_face(2, 7, 4)
+        >>> face3 = m.add_face(5, 3, 2)
+        >>> face4 = m.add_face(2, 1, 9)
+        >>> face5 = m.add_face(4, 7, 10)
+        >>> face6 = m.add_face(4, 10, 11)
+        >>> face7 = m.add_face(11, 10, 12)
+        >>> face8 = m.add_face(1, 0, 13)
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(7, face1)
+        4
+        >>> t.faces[4] == face1 # check result from build
+        True
+        >>> t.stripped_faces
+        {0, 1, 2, 5, 6, 7, 8}
+        >>> t.faces
+        [Face(10, 12, 11), Face(4, 10, 11), Face(4, 7, 10), Face(2, 7, 4), Face(1, 7, 2), Face(0, 1, 2), Face(0, 13, 1)]
+        >>> t.vertices
+        [12, 11, 10, 4, 7, 2, 1, 0, 13]
+        >>> t.reversed_
+        False
+        >>> t.get_strip()
+        [12, 11, 10, 4, 7, 2, 1, 0, 13]
+
+        Mesh which has more than a single strip
+        ---------------------------------------
+
+        >>> m = Mesh()
+        >>> tmp = m.add_face(2, 1, 7) # in strip
+        >>> start_face = m.add_face(0, 1, 2) # in strip
+        >>> tmp = m.add_face(2, 7, 4) # in strip
+        >>> tmp = m.add_face(4, 7, 11) # in strip
+        >>> tmp = m.add_face(5, 3, 2)
+        >>> tmp = m.add_face(1, 0, 8) # in strip
+        >>> tmp = m.add_face(0, 8, 9) # bad orientation!
+        >>> tmp = m.add_face(8, 0, 10) # in strip
+        >>> m.lock()
+        >>> t = TriangleStrip()
+        >>> t.build(0, start_face)
+        2
+        >>> t.vertices
+        [10, 8, 0, 1, 2, 7, 4, 11]
+        >>> t.get_strip()
+        [10, 8, 0, 1, 2, 7, 4, 11]
+        """
+        del self.faces[:]
+        del self.vertices[:]
+        self.reversed_ = False
+        v0 = start_vertex
+        v1 = start_face.get_next_vertex(v0)
+        v2 = start_face.get_next_vertex(v1)
+        self.stripped_faces.add(start_face.index)
+        self.faces.append(start_face)
+        self.vertices.append(v0)
+        self.vertices.append(v1)
+        self.vertices.append(v2)
+        self.traverse_faces(v0, start_face, True)
+        return self.traverse_faces(v2, start_face, False)
+
+    def get_strip(self):
+        """Get strip in forward winding."""
+        strip = []
+        if self.reversed_:
+            if len(self.vertices) & 1:
+                strip = list(reversed(self.vertices))
+            elif len(self.vertices) == 4:
+                strip = list(self.vertices[i] for i in (0, 2, 1, 3))
+            else:
+                strip = list(self.vertices)
+                strip.insert(0, strip[0])
+        else:
+            strip = list(self.vertices)
+        return strip
+
+class Experiment(object):
+    """A stripification experiment, essentially consisting of a set of
+    adjacent strips.
+    """
+
+    def __init__(self, start_vertex, start_face):
+        self.stripped_faces = set()
+        self.start_vertex = start_vertex
+        self.start_face = start_face
+        self.strips = []
+
+    def build(self):
+        """Build strips, starting from start_vertex and start_face.
+
+        >>> m = Mesh()
+        >>> tmp = m.add_face(2, 1, 7)
+        >>> s1_face = m.add_face(0, 1, 2)
+        >>> tmp = m.add_face(2, 7, 4) # in strip
+        >>> tmp = m.add_face(4, 7, 11) # in strip
+        >>> tmp = m.add_face(5, 3, 2)
+        >>> tmp = m.add_face(1, 0, 8) # in strip
+        >>> tmp = m.add_face(0, 8, 9) # bad orientation!
+        >>> tmp = m.add_face(8, 0, 10) # in strip
+        >>> tmp = m.add_face(10, 11, 8) # in strip
+        >>> # parallel strip
+        >>> s2_face = m.add_face(0, 2, 21) # in strip
+        >>> tmp = m.add_face(21, 2, 22) # in strip
+        >>> tmp = m.add_face(2, 4, 22) # in strip
+        >>> tmp = m.add_face(21, 24, 0) # in strip
+        >>> tmp = m.add_face(9, 0, 24) # in strip
+        >>> # parallel strip, further down
+        >>> s3_face = m.add_face(8, 11, 31) # in strip
+        >>> tmp = m.add_face(8, 31, 32) # in strip
+        >>> tmp = m.add_face(31, 11, 33) # in strip
+        >>> m.lock()
+        >>> # build experiment
+        >>> exp = Experiment(0, s1_face)
+        >>> exp.build()
+        >>> len(exp.strips)
+        2
+        >>> exp.strips[0].get_strip()
+        [11, 4, 7, 2, 1, 0, 8, 10, 11]
+        >>> exp.strips[1].get_strip()
+        [4, 22, 2, 21, 0, 24, 9]
+        >>> # note: with current algorithm [32, 8, 31, 11, 33] is not found
+        """
+        # build initial strip
+        strip = TriangleStrip(stripped_faces=self.stripped_faces)
+        strip.build(self.start_vertex, self.start_face)
+        self.strips.append(strip)
+        # build adjacent strips
+        num_faces = len(strip.faces)
+        if num_faces >= 4:
+            face_index = num_faces >> 1 # quick / 2
+            self.build_adjacent(strip, face_index)
+            self.build_adjacent(strip, face_index + 1)
+        elif num_faces == 3:
+            if not self.build_adjacent(strip, 0):
+                self.build_adjacent(strip, 2)
+            self.build_adjacent(strip, 1)
+        elif num_faces == 2:
+            self.build_adjacent(strip, 0)
+            self.build_adjacent(strip, 1)
+        elif num_faces == 1:
+            self.build_adjacent(strip, 0)
+
+    def build_adjacent(self, strip, face_index):
+        """Build strips adjacent to given strip, and add them to the
+        experiment. This is a helper function used by build.
+        """
+        opposite_vertex = strip.vertices[face_index + 1]
+        face = strip.faces[face_index]
+        other_face = strip.get_unstripped_adjacent_face(face, opposite_vertex)
+        if other_face:
+            winding = strip.reversed_
+            if face_index & 1:
+                winding = not winding
+            other_strip = TriangleStrip(stripped_faces=self.stripped_faces)
+            if winding:
+                other_vertex = strip.vertices[face_index]
+                face_index = other_strip.build(other_vertex, other_face)
+            else:
+                other_vertex = strip.vertices[face_index + 2]
+                face_index = other_strip.build(other_vertex, other_face)
+            self.strips.append(other_strip)
+            if face_index > (len(other_strip.faces) >> 1): # quick / 2
+                self.build_adjacent(other_strip, face_index - 1)
+            elif face_index < len(other_strip.faces) - 1:
+                self.build_adjacent(other_strip, face_index + 1)
+            return True
+        return False
+
+class ExperimentSelector(object):
+
+    def __init__(self):
+        self.best_score = -1.0
+        self.best_experiment = None
+
+    def update(self, experiment):
+        """Updates best experiment with given experiment, if given
+        experiment beats current experiment.
+        """
+        score = (sum((len(strip.faces) for strip in experiment.strips), 0.0)
+                 / len(experiment.strips))
+        if score > self.best_score:
+            self.best_score = score
+            self.best_experiment = experiment
+
+    def clear(self):
+        """Remove best experiment, to start a fresh sequence of
+        experiments.
+        """
+        self.best_score = -1.0
+        self.best_experiment = None
+
+class TriangleStripifier(object):
+    """Implementation of a triangle stripifier.
+
+    Heavily adapted from NvTriStrip.
+    Original can be found at http://developer.nvidia.com/view.asp?IO=nvtristrip_library.
+    """
+
+    def __init__(self, mesh):
+        self.num_samples = 10
+        self.mesh = mesh
+
+    @staticmethod
+    def sample(population, k):
+        """Return a k length list of unique elements chosen from the
+        population sequence. Used for random sampling without
+        replacement. Deterministic version of random.sample (being
+        deterministic means that it is easier to test).
+
+        >>> TriangleStripifier.sample(range(10), 1)
+        [0]
+        >>> TriangleStripifier.sample(range(10), 2)
+        [0, 9]
+        >>> TriangleStripifier.sample(range(10), 3)
+        [0, 4, 9]
+        >>> TriangleStripifier.sample(range(10), 4)
+        [0, 3, 6, 9]
+        >>> TriangleStripifier.sample(range(10), 5)
+        [0, 2, 4, 6, 9]
+        >>> TriangleStripifier.sample(range(10), 6)
+        [0, 1, 3, 5, 7, 9]
+        >>> TriangleStripifier.sample(range(10), 7)
+        [0, 1, 3, 4, 6, 7, 9]
+        >>> TriangleStripifier.sample(range(10), 8)
+        [0, 1, 2, 3, 5, 6, 7, 9]
+        >>> TriangleStripifier.sample(range(10), 9)
+        [0, 1, 2, 3, 4, 5, 6, 7, 9]
+        >>> TriangleStripifier.sample(range(10), 10)
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        """
+        if k == 1:
+            # corner case
+            return [population[0]]
+        else:
+            # all other cases
+            return [
+                population[int((i * (float(len(population)) - 1)) / (k - 1))]
+                for i in range(k)]
+
+    def find_all_strips(self):
+        """Find all strips.
+
+        Empty mesh
+        ----------
+
+        >>> m = Mesh()
+        >>> m.lock()
+        >>> ts = TriangleStripifier(m)
+        >>> ts.find_all_strips()
+        []
+
+        Full mesh
+        ---------
+
+        >>> m = Mesh()
+        >>> tmp = m.add_face(2, 1, 7)
+        >>> tmp = m.add_face(0, 1, 2)
+        >>> tmp = m.add_face(2, 7, 4) # in strip
+        >>> tmp = m.add_face(4, 7, 11) # in strip
+        >>> tmp = m.add_face(5, 3, 2)
+        >>> tmp = m.add_face(1, 0, 8) # in strip
+        >>> tmp = m.add_face(0, 8, 9) # bad orientation!
+        >>> tmp = m.add_face(8, 0, 10) # in strip
+        >>> tmp = m.add_face(10, 11, 8) # in strip
+        >>> # parallel strip
+        >>> tmp = m.add_face(0, 2, 21) # in strip
+        >>> tmp = m.add_face(21, 2, 22) # in strip
+        >>> tmp = m.add_face(2, 4, 22) # in strip
+        >>> tmp = m.add_face(21, 24, 0) # in strip
+        >>> tmp = m.add_face(9, 0, 24) # in strip
+        >>> # parallel strip, further down
+        >>> tmp = m.add_face(8, 11, 31) # in strip
+        >>> tmp = m.add_face(8, 31, 32) # in strip
+        >>> tmp = m.add_face(31, 11, 33) # in strip
+        >>> m.lock()
+        >>> ts = TriangleStripifier(m)
+        >>> sorted(ts.find_all_strips())
+        [[3, 2, 5], [4, 22, 2, 21, 0, 24, 9], [9, 0, 8], [11, 4, 7, 2, 1, 0, 8, 10, 11], [32, 8, 31, 11, 33]]
+        """
+        all_strips = []
+        selector = ExperimentSelector()
+        unstripped_faces = set(range(len(self.mesh.faces)))
+        while True:
+            experiments = []
+            # note: using deterministic self.sample
+            # instead of existing random.sample in python
+            # because deterministic version is easier to test
+            for sample in self.sample(list(unstripped_faces),
+                                      min(self.num_samples,
+                                          len(unstripped_faces))):
+                exp_face = self.mesh.faces[sample]
+                for exp_vertex in exp_face.verts:
+                    experiments.append(
+                        Experiment(start_vertex=exp_vertex,
+                                   start_face=exp_face))
+            if not experiments:
+                # done!
+                return all_strips
+            # note: use while loop so we only need to keep at most two
+            # built experiments at the same time in memory
+            while experiments:
+                experiment = experiments.pop()
+                experiment.build()
+                selector.update(experiment)
+            unstripped_faces -= selector.best_experiment.stripped_faces
+            # remove stripped faces from mesh
+            for strip in selector.best_experiment.strips:
+                for face in strip.faces:
+                    self.mesh.discard_face(face)
+            # calculate actual strips for experiment
+            all_strips.extend(
+                (strip.get_strip()
+                 for strip in selector.best_experiment.strips))
+            selector.clear()
+
+if __name__=='__main__':
+    import doctest
+    doctest.testmod()

--- a/gtaLib/pyffi/utils/tristrip.py
+++ b/gtaLib/pyffi/utils/tristrip.py
@@ -1,0 +1,547 @@
+"""A wrapper for TriangleStripifier and some utility functions, for
+stripification of sets of triangles, stitching and unstitching strips,
+and triangulation of strips."""
+
+# ***** BEGIN LICENSE BLOCK *****
+#
+# Copyright (c) 2007-2012, Python File Format Interface
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above
+#      copyright notice, this list of conditions and the following
+#      disclaimer in the documentation and/or other materials provided
+#      with the distribution.
+#
+#    * Neither the name of the Python File Format Interface
+#      project nor the names of its contributors may be used to endorse
+#      or promote products derived from this software without specific
+#      prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# ***** END LICENSE BLOCK *****
+
+try:
+    import pytristrip
+except ImportError:
+    pytristrip = None
+    from .trianglestripifier import TriangleStripifier
+    from .trianglemesh import Mesh
+
+def triangulate(strips):
+    """A generator for iterating over the faces in a set of
+    strips. Degenerate triangles in strips are discarded.
+
+    >>> triangulate([[1, 0, 1, 2, 3, 4, 5, 6]])
+    [(0, 2, 1), (1, 2, 3), (2, 4, 3), (3, 4, 5), (4, 6, 5)]
+    """
+
+    triangles = []
+
+    for strip in strips:
+        if len(strip) < 3: continue # skip empty strips
+        # make list copy incase input data does not like slice notation
+        strip_list = list(strip)
+        # flips the order of verts in every other tri
+        flip = False
+        for i in range(0, len(strip_list)-2):
+            flip = not flip
+            t0, t1, t2 = strip_list[i:i+3]
+            # skip degenerate tri
+            if t0 == t1 or t1 == t2 or t2 == t0: continue
+            # append tri in correct order
+            triangles.append((t0, t1, t2) if flip else (t0, t2, t1))
+
+    return triangles
+
+def _generate_faces_from_triangles(triangles):
+    """Creates faces (tris) from a flat list of non-overlapping triangle indices"""
+    for i in range(0, len(triangles), 3):
+        yield triangles[i], triangles[i+1], triangles[i+2]
+
+def _sort_triangle_indices(triangles):
+    """Sorts indices of each triangle so lowest index always comes first.
+    Also removes degenerate triangles.
+
+    >>> list(_sort_triangle_indices([(2,1,3),(0,2,6),(9,8,4)]))
+    [(1, 3, 2), (0, 2, 6), (4, 9, 8)]
+    >>> list(_sort_triangle_indices([(2,1,1),(0,2,6),(9,8,4)]))
+    [(0, 2, 6), (4, 9, 8)]
+    """
+    for t0, t1, t2 in triangles:
+        # skip degenerate triangles
+        if t0 == t1 or t1 == t2 or t2 == t0:
+            continue
+        # sort indices
+        if t0 < t1 and t0 < t2:
+            yield (t0, t1, t2)
+        elif t1 < t0 and t1 < t2:
+            yield (t1, t2, t0)
+        elif t2 < t0 and t2 < t1:
+            yield (t2, t0, t1)
+        else:
+            # should *never* happen
+            raise RuntimeError(
+                "Unexpected error while sorting triangle indices.")
+
+def _check_strips(triangles, strips):
+    """Checks that triangles and strips describe the same geometry.
+
+    >>> _check_strips([(0,1,2),(2,1,3)], [[0,1,2,3]])
+    >>> _check_strips([(0,1,2),(2,1,3)], [[3,2,1,0]])
+    >>> _check_strips([(0,1,2),(2,1,3)], [[3,2,1,0,1]])
+    >>> _check_strips([(0,1,2),(2,1,3)], [[3,3,3,2,1,0,1]])
+    >>> _check_strips([(0,1,2),(2,1,3),(1,0,1)], [[0,1,2,3]])
+    >>> _check_strips([(0,1,2),(2,1,3),(4,4,4)], [[0,1,2,3]])
+    >>> _check_strips([(0,1,2),(2,1,3)], [[0,1,2,3], [2,3,4]]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+    >>> _check_strips([(0,1,2),(2,1,3),(2,3,4)], [[0,1,2,3]]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+    >>> _check_strips([(0,1,2),(2,1,3),(2,3,4),(3,8,1)], [[0,1,2,3,7],[9,10,5,9]]) # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    ValueError: ...
+    """
+    # triangulate
+    strips_triangles = set(_sort_triangle_indices(triangulate(strips)))
+    triangles = set(_sort_triangle_indices(triangles))
+    # compare
+    if strips_triangles != triangles:
+        raise ValueError(
+            "triangles and strips do not match\n"
+            "triangles = %s\n"
+            "strips = %s\n"
+            "triangles - strips = %s\n"
+            "strips - triangles = %s\n"
+            % (triangles, strips,
+               triangles - strips_triangles,
+               strips_triangles - triangles))
+
+def stripify(triangles, stitchstrips = False):
+    """Converts triangles into a list of strips.
+
+    If stitchstrips is True, then everything is wrapped in a single strip using
+    degenerate triangles.
+
+    >>> triangles = [(0,1,4),(1,2,4),(2,3,4),(3,0,4)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips)
+    >>> triangles = [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10, 11), (12, 13, 14), (15, 16, 17), (18, 19, 20), (21, 22, 23)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips)
+    >>> triangles = [(0, 1, 2), (0, 1, 2)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips)
+    >>> triangles = [(0, 1, 2), (2, 1, 0)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips)
+    >>> triangles = [(0, 1, 2), (2, 1, 0), (1, 2, 3)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips) # NvTriStrip gives wrong result
+    >>> triangles = [(0, 1, 2), (0, 1, 3)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips) # NvTriStrip gives wrong result
+    >>> triangles = [(1, 5, 2), (5, 2, 6), (5, 9, 6), (9, 6, 10), (9, 13, 10), (13, 10, 14), (0, 4, 1), (4, 1, 5), (4, 8, 5), (8, 5, 9), (8, 12, 9), (12, 9, 13), (2, 6, 3), (6, 3, 7), (6, 10, 7), (10, 7, 11), (10, 14, 11), (14, 11, 15)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips) # NvTriStrip gives wrong result
+    >>> triangles = [(1, 2, 3), (4, 5, 6), (6, 5, 7), (8, 5, 9), (4, 10, 9), (8, 3, 11), (8, 10, 3), (12, 13, 6), (14, 2, 15), (16, 13, 15), (16, 2, 3), (3, 2, 1)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips) # detects bug reported by PacificMorrowind
+    >>> triangles = [(354, 355, 356), (355, 356, 354), (354, 355, 356), (355, 356, 354), (354, 355, 356), (356, 354, 355), (354, 355, 356), (357, 359, 358),
+    ...              (380, 372, 381), (372, 370, 381), (381, 370, 354), (370, 367, 354), (367, 366, 354), (366, 355, 354), (355, 356, 354), (354, 356, 381),
+    ...              (356, 355, 357), (357, 356, 355), (356, 355, 357), (356, 355, 357), (357, 356, 355)]
+    >>> strips = stripify(triangles)
+    >>> _check_strips(triangles, strips) # NvTriStrip gives wrong result
+    """
+
+    if pytristrip:
+        strips = pytristrip.stripify(triangles)
+    else:
+        strips = []
+        # build a mesh from triangles
+        mesh = Mesh()
+        for face in triangles:
+            try:
+                mesh.add_face(*face)
+            except ValueError:
+                # degenerate face
+                pass
+        mesh.lock()
+
+        # calculate the strip
+        stripifier = TriangleStripifier(mesh)
+        strips = stripifier.find_all_strips()
+
+    # stitch the strips if needed
+    if stitchstrips:
+        return [stitch_strips(strips)]
+    else:
+        return strips
+
+class OrientedStrip:
+    """An oriented strip, with stitching support."""
+
+    def __init__(self, strip):
+        """Construct oriented strip from regular strip (i.e. a list).
+
+        Constructors
+        ------------
+
+        >>> ostrip = OrientedStrip([0,1,2,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        False
+
+        >>> ostrip = OrientedStrip([0,0,1,2,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        True
+        >>> ostrip2 = OrientedStrip(ostrip)
+        >>> ostrip2.vertices
+        [0, 1, 2, 3]
+        >>> ostrip2.reversed
+        True
+
+        >>> ostrip = OrientedStrip(None) # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        TypeError: ...
+
+        Compactify
+        ----------
+
+        >>> ostrip = OrientedStrip([0,0,0,1,2,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        False
+        >>> ostrip = OrientedStrip([0,0,0,0,1,2,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        True
+        >>> ostrip = OrientedStrip([0,0,0,1,2,3,3,3,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        False
+        >>> ostrip = OrientedStrip([0,0,0,0,1,2,3,3,3,3])
+        >>> ostrip.vertices
+        [0, 1, 2, 3]
+        >>> ostrip.reversed
+        True
+        """
+
+        if isinstance(strip, (list, tuple)):
+            # construct from strip
+            self.vertices = list(strip)
+            self.reversed = False
+            self.compactify()
+        elif isinstance(strip, OrientedStrip):
+            # copy constructor
+            self.vertices = strip.vertices[:]
+            self.reversed = strip.reversed
+        else:
+            raise TypeError(
+                "expected list or OrientedStrip, but got %s"
+                % strip.__class__.__name__)
+
+    def compactify(self):
+        """Remove degenerate faces from front and back."""
+        # remove from front
+        if len(self.vertices) < 3:
+            raise ValueError(
+                "strip must have at least one non-degenerate face")
+        while self.vertices[0] == self.vertices[1]:
+            del self.vertices[0]
+            self.reversed = not self.reversed
+            if len(self.vertices) < 3:
+                raise ValueError(
+                    "strip must have at least one non-degenerate face")
+        # remove from back
+        while self.vertices[-1] == self.vertices[-2]:
+            del self.vertices[-1]
+            if len(self.vertices) < 3:
+                raise ValueError(
+                    "strip must have at least one non-degenerate face")
+
+    def reverse(self):
+        """Reverse vertices."""
+        self.vertices.reverse()
+        if len(self.vertices) & 1:
+            self.reversed = not self.reversed
+
+    def __len__(self):
+        if self.reversed:
+            return len(self.vertices) + 1
+        else:
+            return len(self.vertices)
+
+    def __iter__(self):
+        if self.reversed:
+            yield self.vertices[0]
+        for vert in self.vertices:
+            yield vert
+
+    def __str__(self):
+        """String representation.
+
+        >>> print(OrientedStrip([0, 1, 2, 3, 4]))
+        [0, 1, 2, 3, 4]
+        >>> print(OrientedStrip([0, 0, 1, 2, 3, 4]))
+        [0, 0, 1, 2, 3, 4]
+        """
+        return str(list(self))
+
+    def __repr__(self):
+        return "OrientedStrip(%s)" % str(list(self))
+
+    def get_num_stitches(self, other):
+        """Get number of stitches required to glue the vertices of self to
+        other.
+        """
+        # do last vertex of self and first vertex of other match?
+        has_common_vertex = (self.vertices[-1] == other.vertices[0])
+
+        # do windings match?
+        if len(self.vertices) & 1:
+            has_winding_match = (self.reversed != other.reversed)
+        else:
+            has_winding_match = (self.reversed == other.reversed)
+
+        # append stitches
+        if has_common_vertex:
+            if has_winding_match:
+                return 0
+            else:
+                return 1
+        else:
+            if has_winding_match:
+                return 2
+            else:
+                return 3
+
+    def __add__(self, other):
+        """Combine two strips, using minimal number of stitches.
+
+        >>> # stitch length 0 code path
+        >>> OrientedStrip([0,1,2,3]) + OrientedStrip([3,4,5])
+        OrientedStrip([0, 1, 2, 3, 3, 4, 5])
+        >>> OrientedStrip([0,1,2]) + OrientedStrip([2,2,3,4])
+        OrientedStrip([0, 1, 2, 2, 3, 4])
+
+        >>> # stitch length 1 code path
+        >>> OrientedStrip([0,1,2]) + OrientedStrip([2,3,4])
+        OrientedStrip([0, 1, 2, 2, 2, 3, 4])
+        >>> OrientedStrip([0,1,2,3]) + OrientedStrip([3,3,4,5])
+        OrientedStrip([0, 1, 2, 3, 3, 3, 4, 5])
+
+        >>> # stitch length 2 code path
+        >>> OrientedStrip([0,1,2,3]) + OrientedStrip([7,8,9])
+        OrientedStrip([0, 1, 2, 3, 3, 7, 7, 8, 9])
+        >>> OrientedStrip([0,1,2]) + OrientedStrip([7,7,8,9])
+        OrientedStrip([0, 1, 2, 2, 7, 7, 8, 9])
+
+        >>> # stitch length 3 code path
+        >>> OrientedStrip([0,1,2,3]) + OrientedStrip([7,7,8,9])
+        OrientedStrip([0, 1, 2, 3, 3, 7, 7, 7, 8, 9])
+        >>> OrientedStrip([0,1,2]) + OrientedStrip([7,8,9])
+        OrientedStrip([0, 1, 2, 2, 7, 7, 7, 8, 9])
+        """
+        # make copy of self
+        result = OrientedStrip(self)
+
+        # get number of stitches required
+        num_stitches = self.get_num_stitches(other)
+        if num_stitches >= 4 or num_stitches < 0:
+            # should *never* happen
+            raise RuntimeError("Unexpected error during stitching.")
+
+        # append stitches
+        if num_stitches >= 1:
+            result.vertices.append(self.vertices[-1]) # first stitch
+        if num_stitches >= 2:
+            result.vertices.append(other.vertices[0]) # second stitch
+        if num_stitches >= 3:
+            result.vertices.append(other.vertices[0]) # third stitch
+
+        # append other vertices
+        result.vertices.extend(other.vertices)
+
+        return result
+
+def stitch_strips(strips):
+    """Stitch strips keeping stitch size minimal.
+
+    >>> # stitch length 0 code path
+    >>> stitch_strips([[3,4,5],[0,1,2,3]])
+    [0, 1, 2, 3, 3, 4, 5]
+    >>> stitch_strips([[2,2,3,4],[0,1,2]])
+    [0, 1, 2, 2, 3, 4]
+
+    >>> # check result when changing ordering of strips
+    >>> stitch_strips([[0,1,2,3],[3,4,5]])
+    [0, 1, 2, 3, 3, 4, 5]
+
+    >>> # check result when changing direction of strips
+    >>> stitch_strips([[3,2,1,0],[3,4,5]])
+    [0, 1, 2, 3, 3, 4, 5]
+
+    >>> # stitch length 1 code path
+    >>> stitch_strips([[2,3,4],[0,1,2]])
+    [0, 1, 2, 2, 2, 3, 4]
+    >>> stitch_strips([[3,3,4,5],[0,1,2,3]])
+    [0, 1, 2, 3, 3, 3, 4, 5]
+
+    >>> # stitch length 2 code path
+    >>> stitch_strips([[7,8,9],[0,1,2,3]])
+    [0, 1, 2, 3, 3, 7, 7, 8, 9]
+    >>> stitch_strips([[7,7,8,9],[0,1,2]])
+    [0, 1, 2, 2, 7, 7, 8, 9]
+
+    >>> # stitch length 3 code path... but algorithm reverses strips so
+    >>> # only 2 stitches are needed (compare with OrientedStrip doctest)
+    >>> stitch_strips([[7,7,8,9],[0,1,2,3]])
+    [3, 2, 1, 0, 0, 9, 9, 8, 7]
+    >>> stitch_strips([[7,8,9],[0,1,2]])
+    [0, 1, 2, 2, 9, 9, 8, 7]
+    """
+
+    class ExperimentSelector:
+        """Helper class to select best experiment."""
+        def __init__(self):
+            self.best_ostrip1 = None
+            self.best_ostrip2 = None
+            self.best_num_stitches = None
+            self.best_ostrip_index = None
+
+        def update(self, ostrip_index, ostrip1, ostrip2):
+            num_stitches = ostrip1.get_num_stitches(ostrip2)
+            if ((self.best_num_stitches is None)
+                or (num_stitches < self.best_num_stitches)):
+                self.best_ostrip1 = ostrip1
+                self.best_ostrip2 = ostrip2
+                self.best_ostrip_index = ostrip_index
+                self.best_num_stitches = num_stitches
+
+    # get all strips and their orientation, and their reverse
+    ostrips = [(OrientedStrip(strip), OrientedStrip(strip))
+               for strip in strips if len(strip) >= 3]
+    for ostrip, reversed_ostrip in ostrips:
+        reversed_ostrip.reverse()
+    # start with one of the strips
+    if not ostrips:
+        # no strips!
+        return []
+    result = ostrips.pop()[0]
+    # go on as long as there are strips left to process
+    while ostrips:
+        selector = ExperimentSelector()
+
+        for ostrip_index, (ostrip, reversed_ostrip) in enumerate(ostrips):
+            # try various ways of stitching strips
+            selector.update(ostrip_index, result, ostrip)
+            selector.update(ostrip_index, ostrip, result)
+            selector.update(ostrip_index, result, reversed_ostrip)
+            selector.update(ostrip_index, reversed_ostrip, result)
+            # break early if global optimum is already reached
+            if selector.best_num_stitches == 0:
+                break
+        # get best result, perform the actual stitching, and remove
+        # strip from ostrips
+        result = selector.best_ostrip1 + selector.best_ostrip2
+        ostrips.pop(selector.best_ostrip_index)
+    # get strip
+    strip = list(result)
+    # check if we can remove first vertex by reversing strip
+    if strip[0] == strip[1] and (len(strip) & 1 == 0):
+        strip = strip[1:]
+        strip.reverse()
+    # return resulting strip
+    return strip
+
+def unstitch_strip(strip):
+    """Revert stitched strip back to a set of strips without stitches.
+
+    >>> strip = [0,1,2,2,3,3,4,5,6,7,8]
+    >>> triangles = triangulate([strip])
+    >>> strips = unstitch_strip(strip)
+    >>> _check_strips(triangles, strips)
+    >>> strips
+    [[0, 1, 2], [3, 3, 4, 5, 6, 7, 8]]
+    >>> strip = [0,1,2,3,3,4,4,4,5,6,7,8]
+    >>> triangles = triangulate([strip])
+    >>> strips = unstitch_strip(strip)
+    >>> _check_strips(triangles, strips)
+    >>> strips
+    [[0, 1, 2, 3], [4, 4, 5, 6, 7, 8]]
+    >>> strip = [0,1,2,3,4,4,4,4,5,6,7,8]
+    >>> triangles = triangulate([strip])
+    >>> strips = unstitch_strip(strip)
+    >>> _check_strips(triangles, strips)
+    >>> strips
+    [[0, 1, 2, 3, 4], [4, 4, 5, 6, 7, 8]]
+    >>> strip = [0,1,2,3,4,4,4,4,4,5,6,7,8]
+    >>> triangles = triangulate([strip])
+    >>> strips = unstitch_strip(strip)
+    >>> _check_strips(triangles, strips)
+    >>> strips
+    [[0, 1, 2, 3, 4], [4, 5, 6, 7, 8]]
+    >>> strip = [0,0,1,1,2,2,3,3,4,4,4,4,4,5,5,6,6,7,7,8,8]
+    >>> triangles = triangulate([strip])
+    >>> strips = unstitch_strip(strip)
+    >>> _check_strips(triangles, strips)
+    >>> strips
+    []"""
+    strips = []
+    currentstrip = []
+    i = 0
+    while i < len(strip)-1:
+        winding = i & 1
+        currentstrip.append(strip[i])
+        if strip[i] == strip[i+1]:
+            # stitch detected, add current strip to list of strips
+            strips.append(currentstrip)
+            # and start a new one, taking into account winding
+            if winding == 1:
+                currentstrip = []
+            else:
+                currentstrip = [strip[i+1]]
+        i += 1
+    # add last part
+    currentstrip.extend(strip[i:])
+    strips.append(currentstrip)
+    # sanitize strips
+    for strip in strips:
+        while len(strip) >= 3 and strip[0] == strip[1] == strip[2]:
+            strip.pop(0)
+            strip.pop(0)
+    return [strip for strip in strips if len(strip) > 3 or (len(strip) == 3 and strip[0] != strip[1])]
+
+if __name__=='__main__':
+    import doctest
+    doctest.testmod()

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -238,6 +238,7 @@ class OBJECT_PT_dffObjects(bpy.types.Panel):
         box.prop(settings, "export_normals", text="Export Normals")
         box.prop(settings, "export_split_normals", text="Export Custom Split Normals")
         box.prop(settings, "export_binsplit", text="Export Bin Mesh PLG")
+        box.prop(settings, "triangle_strip", text="Use Triangle Strip")
         box.prop(settings, "light", text="Enable Lighting")
         box.prop(settings, "modulate_color", text="Enable Modulate Material Color")
             
@@ -447,6 +448,11 @@ class DFFObjectProps(bpy.types.PropertyGroup):
         default=True,
         description="Enabling will increase file size, but will increase\
 compatibiility with DFF Viewers"
+    )
+    
+    triangle_strip : bpy.props.BoolProperty(
+        default=False,
+        description="Use Triangle Strip instead of Triangle List for Bin Mesh PLG"
     )
 
     col_material : bpy.props.IntProperty(

--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -778,6 +778,7 @@ class dff_exporter:
         geometry.export_flags['write_mesh_plg'] = obj.dff.export_binsplit
         geometry.export_flags['light'] = obj.dff.light
         geometry.export_flags['modulate_color'] = obj.dff.modulate_color
+        geometry.export_flags['triangle_strip'] = obj.dff.triangle_strip
         
         if "dff_user_data" in obj.data:
             geometry.extensions['user_data'] = dff.UserData.from_mem(

--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -126,6 +126,7 @@ class dff_importer:
             mesh['dragon_light'] = (geom.flags & dff.rpGEOMETRYLIGHT) != 0
             mesh['dragon_modulate_color'] = \
                 (geom.flags & dff.rpGEOMETRYMODULATEMATERIALCOLOR) != 0
+            mesh['dragon_triangle_strip'] = (geom.flags & dff.rpGEOMETRYTRISTRIP) != 0
 
             uv_layers = []
             
@@ -691,6 +692,7 @@ class dff_importer:
                     obj.dff.export_normals = mesh['dragon_normals']
                     obj.dff.light          = mesh['dragon_light']
                     obj.dff.modulate_color = mesh['dragon_modulate_color']
+                    obj.dff.triangle_strip = mesh['dragon_triangle_strip']
 
                     if obj.dff.pipeline == 'CUSTOM':
                         obj.dff.custom_pipeline = mesh['dragon_cust_pipeline']
@@ -701,6 +703,7 @@ class dff_importer:
                     del mesh['dragon_cust_pipeline' ]
                     del mesh['dragon_light'         ]
                     del mesh['dragon_modulate_color']
+                    del mesh['dragon_triangle_strip']
                     
                 # Set vertex groups
                 if index in self.skin_data:


### PR DESCRIPTION
Added the option to export Triangle Strip instead of Triangel List for Bin Mesh PLG. It will reduce the size of the exported file. Triangle stripper implementation taken from [pyffi](https://github.com/niftools/pyffi)

![image](https://github.com/Parik27/DragonFF/assets/31922454/4594b4a2-0813-485a-a036-a1a4f2675001)

![image](https://github.com/Parik27/DragonFF/assets/31922454/c88d9422-981d-4650-9b03-f0ec9897e845)