### PR TITLE
use bmesh.from_edit_mesh in edit mode

### DIFF
--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -35,9 +35,13 @@ class col_exporter:
     def _process_mesh(obj, verts, faces):
 
         mesh = obj.data
-        bm   = bmesh.new()
 
-        bm.from_mesh(mesh)
+        if obj.mode == "EDIT":
+            bm = bmesh.from_edit_mesh(mesh)
+        else:
+            bm = bmesh.new()
+            bm.from_mesh(mesh)
+
         bmesh.ops.triangulate(bm, faces=bm.faces[:])
 
         vert_offset = len(verts)


### PR DESCRIPTION
If you're exporting in edit mode, current meshes are not exported, but rather pre-edit ones. 
This commit checks object.mode == "EDIT" and use bmesh.from_edit_mesh to get meshes for export.