### PR TITLE
Map import collisions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,8 @@ def register():
     else:
         bpy.types.TOPBAR_MT_file_import.append(gui.import_dff_func)
         bpy.types.TOPBAR_MT_file_export.append(gui.export_dff_func)
-        bpy.types.OUTLINER_MT_collection.append(gui.export_col_func)
+        bpy.types.OUTLINER_MT_collection.append(gui.export_col_outliner)
+        bpy.types.OUTLINER_MT_object.append(gui.export_dff_outliner)
 
     
 
@@ -73,7 +74,8 @@ def unregister():
     else:
         bpy.types.TOPBAR_MT_file_import.remove(gui.import_dff_func)
         bpy.types.TOPBAR_MT_file_export.remove(gui.export_dff_func)
-        bpy.types.OUTLINER_MT_collection.remove(gui.export_col_func)
+        bpy.types.OUTLINER_MT_collection.remove(gui.export_col_outliner)
+        bpy.types.OUTLINER_MT_object.remove(gui.export_dff_outliner)
 
     # Unregister all the classes
     for cls in _classes:

--- a/__init__.py
+++ b/__init__.py
@@ -61,6 +61,7 @@ def register():
         bpy.types.TOPBAR_MT_file_export.append(gui.export_dff_func)
         bpy.types.OUTLINER_MT_collection.append(gui.export_col_outliner)
         bpy.types.OUTLINER_MT_object.append(gui.export_dff_outliner)
+        bpy.types.SpaceView3D.draw_handler_add(gui.DFFSceneProps.draw_fg, (), 'WINDOW', 'POST_VIEW')
 
     
 

--- a/__init__.py
+++ b/__init__.py
@@ -36,6 +36,7 @@ _classes = [
     gui.IMPORT_OT_dff,
     gui.EXPORT_OT_dff,
     gui.EXPORT_OT_col,
+    gui.OBJECT_OT_facegoups_col,
     gui.MATERIAL_PT_dffMaterials,
     gui.OBJECT_PT_dffObjects,
     gui.DFFMaterialProps,

--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,8 @@ def register():
     else:
         bpy.types.TOPBAR_MT_file_import.append(gui.import_dff_func)
         bpy.types.TOPBAR_MT_file_export.append(gui.export_dff_func)
-        
+        bpy.types.OUTLINER_MT_collection.append(gui.export_col_func)
+
     
 
 #######################################################
@@ -72,7 +73,8 @@ def unregister():
     else:
         bpy.types.TOPBAR_MT_file_import.remove(gui.import_dff_func)
         bpy.types.TOPBAR_MT_file_export.remove(gui.export_dff_func)
-    
+        bpy.types.OUTLINER_MT_collection.remove(gui.export_col_func)
+
     # Unregister all the classes
     for cls in _classes:
         unregister_class(cls)      

--- a/data/map_data.py
+++ b/data/map_data.py
@@ -106,45 +106,45 @@ SA_structures['occl'] = namedtuple("IPL_TCYC_SA", "x1 y1 z1 x2 y2 z2 farClip ext
 
 # OBJS
 # Defines simple objects. They can be placed into the world through the inst section of the item placement files.
-III_structures['objs_1'] = namedtuple("IDE_OBJS_3_1",  "id modelName txdName drawDistance flags")
-III_structures['objs_2'] = namedtuple("IDE_OBJS_3_2",  "id modelName txdName meshCount drawDistance flags")
-III_structures['objs_3'] = namedtuple("IDE_OBJS_3_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags")
-III_structures['objs_4'] = namedtuple("IDE_OBJS_3_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags")
+III_structures['objs_1'] = namedtuple("IDE_OBJS_3_1",  "id modelName txdName drawDistance flags filename")
+III_structures['objs_2'] = namedtuple("IDE_OBJS_3_2",  "id modelName txdName meshCount drawDistance flags filename")
+III_structures['objs_3'] = namedtuple("IDE_OBJS_3_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags filename")
+III_structures['objs_4'] = namedtuple("IDE_OBJS_3_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags filename")
 
-VC_structures['objs_1'] =  namedtuple("IDE_OBJS_VC_1",  "id modelName txdName drawDistance flags")
-VC_structures['objs_2'] =  namedtuple("IDE_OBJS_VC_2",  "id modelName txdName meshCount drawDistance flags")
-VC_structures['objs_3'] =  namedtuple("IDE_OBJS_VC_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags")
-VC_structures['objs_4'] =  namedtuple("IDE_OBJS_VC_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags")
+VC_structures['objs_1'] =  namedtuple("IDE_OBJS_VC_1",  "id modelName txdName drawDistance flags filename")
+VC_structures['objs_2'] =  namedtuple("IDE_OBJS_VC_2",  "id modelName txdName meshCount drawDistance flags filename")
+VC_structures['objs_3'] =  namedtuple("IDE_OBJS_VC_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags filename")
+VC_structures['objs_4'] =  namedtuple("IDE_OBJS_VC_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags filename")
 
-SA_structures['objs_1'] =  namedtuple("IDE_OBJS_SA_1",  "id modelName txdName drawDistance flags")
-SA_structures['objs_2'] =  namedtuple("IDE_OBJS_SA_2",  "id modelName txdName meshCount drawDistance flags")
-SA_structures['objs_3'] =  namedtuple("IDE_OBJS_SA_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags")
-SA_structures['objs_4'] =  namedtuple("IDE_OBJS_SA_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags")
+SA_structures['objs_1'] =  namedtuple("IDE_OBJS_SA_1",  "id modelName txdName drawDistance flags filename")
+SA_structures['objs_2'] =  namedtuple("IDE_OBJS_SA_2",  "id modelName txdName meshCount drawDistance flags filename")
+SA_structures['objs_3'] =  namedtuple("IDE_OBJS_SA_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags filename")
+SA_structures['objs_4'] =  namedtuple("IDE_OBJS_SA_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags filename")
 
 # TOBJ
 # Defines time objects. The section functions similarly to objs but has two additional
 # parameters defining the in-game time range the object can get rendered. These objects
 # can be placed into the world through the inst section of the item placement files.
-III_structures['tobj_1'] = namedtuple("IDE_TOBJ_3_1",  "id modelName txdName drawDistance flags timeOn timeOff")
-III_structures['tobj_2'] = namedtuple("IDE_TOBJ_3_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff")
-III_structures['tobj_3'] = namedtuple("IDE_TOBJ_3_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff")
-III_structures['tobj_4'] = namedtuple("IDE_TOBJ_3_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff")
+III_structures['tobj_1'] = namedtuple("IDE_TOBJ_3_1",  "id modelName txdName drawDistance flags timeOn timeOff filename")
+III_structures['tobj_2'] = namedtuple("IDE_TOBJ_3_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff filename")
+III_structures['tobj_3'] = namedtuple("IDE_TOBJ_3_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff filename")
+III_structures['tobj_4'] = namedtuple("IDE_TOBJ_3_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff filename")
 
-VC_structures['tobj_1'] =  namedtuple("IDE_TOBJ_VC_1",  "id modelName txdName drawDistance flags timeOn timeOff")
-VC_structures['tobj_2'] =  namedtuple("IDE_TOBJ_VC_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff")
-VC_structures['tobj_3'] =  namedtuple("IDE_TOBJ_VC_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff")
-VC_structures['tobj_4'] =  namedtuple("IDE_TOBJ_VC_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff")
+VC_structures['tobj_1'] =  namedtuple("IDE_TOBJ_VC_1",  "id modelName txdName drawDistance flags timeOn timeOff filename")
+VC_structures['tobj_2'] =  namedtuple("IDE_TOBJ_VC_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff filename")
+VC_structures['tobj_3'] =  namedtuple("IDE_TOBJ_VC_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff filename")
+VC_structures['tobj_4'] =  namedtuple("IDE_TOBJ_VC_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff filename")
 
-SA_structures['tobj_1'] =  namedtuple("IDE_TOBJ_SA_1",  "id modelName txdName drawDistance flags timeOn timeOff")
-SA_structures['tobj_2'] =  namedtuple("IDE_TOBJ_SA_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff")
-SA_structures['tobj_3'] =  namedtuple("IDE_TOBJ_SA_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff")
-SA_structures['tobj_4'] =  namedtuple("IDE_TOBJ_SA_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff")
+SA_structures['tobj_1'] =  namedtuple("IDE_TOBJ_SA_1",  "id modelName txdName drawDistance flags timeOn timeOff filename")
+SA_structures['tobj_2'] =  namedtuple("IDE_TOBJ_SA_2",  "id modelName txdName meshCount drawDistance flags timeOn timeOff filename")
+SA_structures['tobj_3'] =  namedtuple("IDE_TOBJ_SA_3",  "id modelName txdName meshCount drawDistance1 drawDistance2 flags timeOn timeOff filename")
+SA_structures['tobj_4'] =  namedtuple("IDE_TOBJ_SA_4",  "id modelName txdName meshCount drawDistance1 drawDistance2 drawDistance3 flags timeOn timeOff filename")
 
 # ANIM
 # Defines animated objects. The section functions similarly to objs but has one
 # additional parameter indicating an IFP or WAD animation file to assign an
 # animation to the object. 
-SA_structures['anim'] = namedtuple("IDE_ANIM_SA", "id modelName textureName animName drawDist flags")
+SA_structures['anim'] = namedtuple("IDE_ANIM_SA", "id modelName textureName animName drawDist flags filename")
 
 # PEDS
 # Defines pedestrian objects (random NPC's)

--- a/gtaLib/col.py
+++ b/gtaLib/col.py
@@ -27,7 +27,7 @@ class ColModel:
         self.model_id      = 0
         self.bounds        = None
         self.spheres       = []
-        self.cubes         = []
+        self.boxes         = []
         self.mesh_verts    = []
         self.mesh_faces    = []
         self.lines         = []
@@ -217,7 +217,7 @@ class coll:
         model.spheres += self.__read_block(TSphere)
         self.__incr(4) # number of unk. data (from GTAModding)
 
-        model.cubes      += self.__read_block(TBox)
+        model.boxes      += self.__read_block(TBox)
         model.mesh_verts += self.__read_block(TVertex)
         model.mesh_faces += self.__read_block(TFace)
 
@@ -243,7 +243,7 @@ class coll:
 
         # Boxes
         self._pos = pos + box_offset + 4
-        model.cubes += self.__read_block(TBox, box_count)
+        model.boxes += self.__read_block(TBox, box_count)
         
         # Faces
         self._pos = pos + faces_offset + 4
@@ -373,7 +373,7 @@ class coll:
 
         data += self.__write_block(TSphere, model.spheres)
         data += pack('<I', 0)
-        data += self.__write_block(TBox, model.cubes)
+        data += self.__write_block(TBox, model.boxes)
         data += self.__write_block(TVertex, model.mesh_verts)
         data += self.__write_block(TFace, model.mesh_faces)
 
@@ -384,7 +384,7 @@ class coll:
         data = b''
 
         flags = 0
-        flags |= 2 if model.spheres or model.cubes or model.mesh_faces else 0
+        flags |= 2 if model.spheres or model.boxes or model.mesh_faces else 0
         flags |= 16 if model.shadow_faces and model.version >= 3 else 0
         
         header_len = 104
@@ -399,7 +399,7 @@ class coll:
 
         # Boxes
         offsets.append(len(data) + header_len)
-        data += self.__write_block(TBox, model.cubes, False)
+        data += self.__write_block(TBox, model.boxes, False)
 
         offsets.append(0) # TODO: Cones
         
@@ -435,7 +435,7 @@ class coll:
         # Write Header
         header_data = pack("<HHHBxIIIIIII",
                             len(model.spheres),
-                            len(model.cubes),
+                            len(model.boxes),
                             len(model.mesh_faces),
                             len(model.lines),
                             flags,

--- a/gtaLib/map.py
+++ b/gtaLib/map.py
@@ -232,14 +232,14 @@ class MapDataUtility:
     ########################################################################
     def getMapData(gameID, gameRoot, iplSection):
         
-        data = map_data.data[gameID]
+        data = map_data.data[gameID].copy()
 
         # Prune IDEs unrelated to current IPL section (SA only). First, make IDE_paths a mutable list, then iterate
         # over a copy so we can remove elements during iteration. This is a naive pruning which keeps all ides with a
         # few generic keywords in their name and culls anything else with a prefix different from the given iplSection
         if gameID == game_version.SA:
             data['IDE_paths'] = list(data['IDE_paths'])
-            for p in list(data['IDE_paths']):
+            for p in data['IDE_paths'].copy():
                 if p.startswith('DATA/MAPS/generic/') or p.startswith('DATA/MAPS/leveldes/') or 'xref' in p:
                     continue
                 ide_prefix = p.split('/')[-1].lower()

--- a/gtaLib/map.py
+++ b/gtaLib/map.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import os
 from ..data import map_data
+from ..ops.importer_common import game_version
 from collections import namedtuple
 import struct
 
@@ -38,6 +40,11 @@ class GenericSectionUtility:
 
             # Split line and trim individual elements
             lineParams = [e.strip() for e in line.split(",")]
+
+            # Append filename for IDEs (needed for collision lookups)
+            fname = os.path.basename(fileStream.name)
+            if fname.lower().endswith('.ide'):
+                lineParams.append(fname)
 
             # Get the correct data structure for this section entry
             dataStructure = self.getDataStructure(lineParams)
@@ -78,13 +85,13 @@ class GenericSectionUtility:
 class OBJSSectionUtility(GenericSectionUtility):
     def getDataStructure(self, lineParams):
 
-        if(len(lineParams) == 5):
+        if(len(lineParams) == 6):
             dataStructure = self.dataStructures["objs_1"]
-        elif(len(lineParams) == 6):
-            dataStructure = self.dataStructures["objs_2"]
         elif(len(lineParams) == 7):
-            dataStructure = self.dataStructures["objs_3"]
+            dataStructure = self.dataStructures["objs_2"]
         elif(len(lineParams) == 8):
+            dataStructure = self.dataStructures["objs_3"]
+        elif(len(lineParams) == 9):
             dataStructure = self.dataStructures["objs_4"]
         else:
             print(type(self).__name__ + " error: Unknown number of line parameters")
@@ -96,13 +103,13 @@ class OBJSSectionUtility(GenericSectionUtility):
 class TOBJSectionUtility(GenericSectionUtility):
     def getDataStructure(self, lineParams):
 
-        if(len(lineParams) == 7):
+        if(len(lineParams) == 8):
             dataStructure = self.dataStructures["tobj_1"]
-        elif(len(lineParams) == 8):
-            dataStructure = self.dataStructures["tobj_2"]
         elif(len(lineParams) == 9):
-            dataStructure = self.dataStructures["tobj_3"]
+            dataStructure = self.dataStructures["tobj_2"]
         elif(len(lineParams) == 10):
+            dataStructure = self.dataStructures["tobj_3"]
+        elif(len(lineParams) == 11):
             dataStructure = self.dataStructures["tobj_4"]
         else:
             print(type(self).__name__ + " error: Unknown number of line parameters")
@@ -225,8 +232,20 @@ class MapDataUtility:
     ########################################################################
     def getMapData(gameID, gameRoot, iplSection):
         
-        # TODO: choose correct IDE/IPL files dict
         data = map_data.data[gameID]
+
+        # Prune IDEs unrelated to current IPL section (SA only). First, make IDE_paths a mutable list, then iterate
+        # over a copy so we can remove elements during iteration. This is a naive pruning which keeps all ides with a
+        # few generic keywords in their name and culls anything else with a prefix different from the given iplSection
+        if gameID == game_version.SA:
+            data['IDE_paths'] = list(data['IDE_paths'])
+            for p in list(data['IDE_paths']):
+                if p.startswith('DATA/MAPS/generic/') or p.startswith('DATA/MAPS/leveldes/') or 'xref' in p:
+                    continue
+                ide_prefix = p.split('/')[-1].lower()
+                ipl_prefix = iplSection.split('/')[-1].lower()[:3]
+                if not ide_prefix.startswith(ipl_prefix):
+                    data['IDE_paths'].remove(p)
 
         ide = {}
 

--- a/gui/col_ot.py
+++ b/gui/col_ot.py
@@ -37,6 +37,11 @@ class EXPORT_OT_col(bpy.types.Operator, ExportHelper):
         name = "Version Export"
     )
 
+    use_active_collection : bpy.props.BoolProperty(
+        name = "Only the objects from the active collection",
+        default = False
+    )
+
     #######################################################
     def draw(self, context):
         layout = self.layout
@@ -51,7 +56,7 @@ class EXPORT_OT_col(bpy.types.Operator, ExportHelper):
             {
                 "file_name"      : self.filepath,
                 "version"        : int(self.export_version),
-                "collection"     : None,
+                "collection"     : context.collection if self.use_active_collection else None,
                 "memory"         : False,
                 "mass_export"    : True,
                 "only_selected"  : self.only_selected

--- a/gui/col_ot.py
+++ b/gui/col_ot.py
@@ -158,7 +158,7 @@ class OBJECT_OT_facegoups_col(bpy.types.Operator):
 
             bm.to_mesh(mesh)
 
-        # Delete face groups if extant on 
+        # Delete face groups if they exist now but the generation found them unnecessary
         elif mesh.attributes.get("face group"):
             mesh.attributes.remove(mesh.attributes.get("face group"))
 

--- a/gui/col_ot.py
+++ b/gui/col_ot.py
@@ -151,9 +151,18 @@ class OBJECT_OT_facegoups_col(bpy.types.Operator):
             bm.from_mesh(mesh)
             bm.faces.ensure_lookup_table()
             layer = bm.faces.layers.int.get("face group")
+            min_size = max_size = len(lil_groups[0]['indices'])
+            avg_size = 0
             for fg, grp in enumerate(lil_groups):
+                grp_size = len(grp['indices'])
+                min_size = min(min_size, grp_size)
+                max_size = max(max_size, grp_size)
+                avg_size += grp_size
                 for idx in grp['indices']:
                     bm.faces[idx][layer] = fg
+            avg_size /= float(len(lil_groups))
+            print("Generated %i face groups with minimum size of %i, a maximum size of %i and an average size of %f "
+                  "faces." % (len(lil_groups), min_size, max_size, avg_size))
             bm.faces.sort(key=lambda f: f[layer])
 
             bm.to_mesh(mesh)
@@ -161,6 +170,7 @@ class OBJECT_OT_facegoups_col(bpy.types.Operator):
         # Delete face groups if they exist now but the generation found them unnecessary
         elif mesh.attributes.get("face group"):
             mesh.attributes.remove(mesh.attributes.get("face group"))
+            print("No face groups were generated with the current settings.")
 
         # Make an undo and force a redraw of the viewport
         bpy.ops.ed.undo_push()

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -180,17 +180,26 @@ class DFF_MT_ExportChoice(bpy.types.Menu):
     def draw(self, context):
         self.layout.operator(EXPORT_OT_dff.bl_idname,
                              text="DragonFF DFF (.dff)")
-        self.layout.operator(EXPORT_OT_col.bl_idname,
+        op = self.layout.operator(EXPORT_OT_col.bl_idname,
                              text="DragonFF Collision (.col)")
-            
-        
-#######################################################
+        op.use_active_collection = False
+
+
+    #######################################################
 def import_dff_func(self, context):
     self.layout.operator(IMPORT_OT_dff.bl_idname, text="DragonFF DFF (.dff)")
 
 #######################################################
 def export_dff_func(self, context):
     self.layout.menu("DFF_MT_ExportChoice", text="DragonFF")
+
+#######################################################
+def export_col_func(self, context):
+    self.layout.separator()
+    self.layout.operator_context = 'INVOKE_DEFAULT'
+    op = self.layout.operator(EXPORT_OT_col.bl_idname, text="Export collection as collision container (.col)")
+    op.use_active_collection = True
+    op.filepath = context.collection.name
 
 #######################################################
 class OBJECT_PT_dffObjects(bpy.types.Panel):

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -178,8 +178,9 @@ class DFF_MT_ExportChoice(bpy.types.Menu):
     bl_label = "DragonFF"
 
     def draw(self, context):
-        self.layout.operator(EXPORT_OT_dff.bl_idname,
+        op = self.layout.operator(EXPORT_OT_dff.bl_idname,
                              text="DragonFF DFF (.dff)")
+        op.from_outliner = False
         op = self.layout.operator(EXPORT_OT_col.bl_idname,
                              text="DragonFF Collision (.col)")
         op.use_active_collection = False
@@ -194,7 +195,14 @@ def export_dff_func(self, context):
     self.layout.menu("DFF_MT_ExportChoice", text="DragonFF")
 
 #######################################################
-def export_col_func(self, context):
+def export_dff_outliner(self, context):
+    self.layout.separator()
+    self.layout.operator_context = 'INVOKE_DEFAULT'
+    op = self.layout.operator(EXPORT_OT_dff.bl_idname, text="Export object as DFF (.dff)")
+    op.from_outliner = True
+
+#######################################################
+def export_col_outliner(self, context):
     self.layout.separator()
     self.layout.operator_context = 'INVOKE_DEFAULT'
     op = self.layout.operator(EXPORT_OT_col.bl_idname, text="Export collection as collision container (.col)")

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -187,7 +187,7 @@ class DFF_MT_ExportChoice(bpy.types.Menu):
 
     #######################################################
 def import_dff_func(self, context):
-    self.layout.operator(IMPORT_OT_dff.bl_idname, text="DragonFF DFF (.dff)")
+    self.layout.operator(IMPORT_OT_dff.bl_idname, text="DragonFF DFF (.dff, col)")
 
 #######################################################
 def export_dff_func(self, context):

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -310,6 +310,9 @@ class OBJECT_PT_dffObjects(bpy.types.Panel):
             if context.object.type == 'EMPTY':
                 self.draw_col_menu(context)
             if context.object.type == 'MESH':
+                layout.prop(context.scene.dff, 'face_group_min', slider=True)
+                layout.prop(context.scene.dff, 'face_group_max', slider=True)
+                layout.prop(context.scene.dff, 'face_group_avoid_smalls')
                 layout.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
     
     #######################################################

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -309,7 +309,8 @@ class OBJECT_PT_dffObjects(bpy.types.Panel):
         elif settings.type == 'COL':
             if context.object.type == 'EMPTY':
                 self.draw_col_menu(context)
-            layout.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
+            if context.object.type == 'MESH':
+                layout.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
     
     #######################################################
     def draw(self, context):

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -310,11 +310,15 @@ class OBJECT_PT_dffObjects(bpy.types.Panel):
             if context.object.type == 'EMPTY':
                 self.draw_col_menu(context)
             if context.object.type == 'MESH':
-                layout.prop(context.scene.dff, 'face_group_min', slider=True)
-                layout.prop(context.scene.dff, 'face_group_max', slider=True)
-                layout.prop(context.scene.dff, 'face_group_avoid_smalls')
-                layout.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
-    
+                settings = context.scene.dff
+                box = layout.box()
+                box.prop(settings, "draw_facegroups", text="Display Face Groups")
+                box.label(text="Face Group Generation:")
+                box.prop(settings, 'face_group_min', slider=True)
+                box.prop(settings, 'face_group_max', slider=True)
+                box.prop(settings, 'face_group_avoid_smalls')
+                box.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
+
     #######################################################
     def draw(self, context):
 

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -1,6 +1,6 @@
 import bpy
 from .dff_ot import EXPORT_OT_dff, IMPORT_OT_dff
-from .col_ot import EXPORT_OT_col
+from .col_ot import EXPORT_OT_col, OBJECT_OT_facegoups_col
 
 #######################################################
 class MATERIAL_PT_dffMaterials(bpy.types.Panel):
@@ -309,6 +309,7 @@ class OBJECT_PT_dffObjects(bpy.types.Panel):
         elif settings.type == 'COL':
             if context.object.type == 'EMPTY':
                 self.draw_col_menu(context)
+            layout.operator(OBJECT_OT_facegoups_col.bl_idname, text=OBJECT_OT_facegoups_col.bl_label)
     
     #######################################################
     def draw(self, context):

--- a/gui/dff_ot.py
+++ b/gui/dff_ot.py
@@ -176,7 +176,7 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
     
     bl_idname      = "import_scene.dff"
     bl_description = 'Import a Renderware DFF or COL File'
-    bl_label       = "DragonFF DFF (.dff)"
+    bl_label       = "DragonFF DFF (.dff, .col)"
 
     filter_glob   : bpy.props.StringProperty(default="*.dff;*.col",
                                               options={'HIDDEN'})
@@ -275,8 +275,14 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
         
         for file in [os.path.join(self.directory,file.name) for file in self.files] if self.files else [self.filepath]:
             if file.endswith(".col"):
-                col_importer.import_col_file(file, os.path.basename(file))
-                            
+                col_list = col_importer.import_col_file(file, os.path.basename(file))
+                # Move all collisions to a top collection named for the file they came from
+                collection = bpy.data.collections.new(os.path.basename(file))
+                context.scene.collection.children.link(collection)
+                for c in col_list:
+                    context.scene.collection.children.unlink(c)
+                    collection.children.link(c)
+
             else:
                 # Set image_ext to none if scan images is disabled
                 image_ext = self.image_ext

--- a/gui/dff_ot.py
+++ b/gui/dff_ot.py
@@ -51,10 +51,10 @@ class EXPORT_OT_dff(bpy.types.Operator, ExportHelper):
         default         = False
     )
     
-    reset_positions     : bpy.props.BoolProperty(
+    preserve_positions     : bpy.props.BoolProperty(
         name            = "Preserve Positions",
         description     = "Don't set object positions to (0,0,0)",
-        default         = False
+        default         = True
     )
     
     export_version      : bpy.props.EnumProperty(
@@ -98,7 +98,7 @@ class EXPORT_OT_dff(bpy.types.Operator, ExportHelper):
             row.label(text="Mass Export:")
 
             row = box.row()
-            row.prop(self, "reset_positions")
+            row.prop(self, "preserve_positions")
 
         layout.prop(self, "only_selected")
         layout.prop(self, "export_coll")
@@ -144,6 +144,7 @@ class EXPORT_OT_dff(bpy.types.Operator, ExportHelper):
                     "directory"          : self.directory,
                     "selected"           : self.only_selected,
                     "mass_export"        : self.mass_export,
+                    "preserve_positions" : self.preserve_positions,
                     "version"            : self.get_selected_rw_version(),
                     "export_coll"        : self.export_coll,
                     "export_frame_names" : self.export_frame_names,

--- a/gui/map.py
+++ b/gui/map.py
@@ -36,6 +36,11 @@ class DFFSceneProps(bpy.types.PropertyGroup):
         default     = False
     )
 
+    load_collisions: bpy.props.BoolProperty(
+        name        = "Load Map Collisions",
+        default     = False
+    )
+
     game_root : bpy.props.StringProperty(
         name = 'Game root',
         default = 'C:/Program Files (x86)/Steam/steamapps/common/',
@@ -88,6 +93,7 @@ class MapImportPanel(bpy.types.Panel):
         col.separator()
         col.prop(settings, "skip_lod", text="Skip LOD objects")
         col.prop(settings, "read_mat_split", text="Read Material Split")
+        col.prop(settings, "load_collisions", text="Load Map Collisions")
 
         layout.separator()
 

--- a/gui/map.py
+++ b/gui/map.py
@@ -1,4 +1,8 @@
 import bpy
+import gpu
+import numpy as np
+import random
+from gpu_extras.batch import batch_for_shader
 from ..data import map_data
 from ..ops.importer_common import game_version
 
@@ -63,7 +67,65 @@ class DFFSceneProps(bpy.types.PropertyGroup):
     #     subtype = 'DIR_PATH'
     #     )
 
-    #######################################################    
+    def draw_fg():
+        if not bpy.context.scene.dff.draw_facegroups:
+            return
+        o = bpy.context.active_object
+        if o and o.type == 'MESH' and o.data.attributes.get('face group'):
+            mesh = bpy.context.active_object.data
+            mesh.calc_loop_triangles()
+
+            # As the face groups are stored as face attributes, we'll generate unique vertices across the whole overlay
+            # because the colors of different faces can't be shared across vertices
+            size = 3 * len(mesh.loop_triangles)
+            vertices = np.empty((size, 3), 'f')
+            vertex_colors = np.empty((size, 4), 'f')
+            indices = np.arange(0, size, dtype='i')
+
+            # Each face group gets a random color, but set an explicit seed so the resulting color array remains
+            # deterministic across redraws
+            random.seed(10)
+            color = []
+            grp = -1
+            idx = 0
+            attr = mesh.attributes['face group'].data
+            for i, face in enumerate(mesh.loop_triangles):
+                vertices[idx  ] = mesh.vertices[face.vertices[0]].co
+                vertices[idx+1] = mesh.vertices[face.vertices[1]].co
+                vertices[idx+2] = mesh.vertices[face.vertices[2]].co
+                if grp != attr[i].value:
+                    color = random.uniform(0.2, 1.0), random.uniform(0.2, 1.0), random.uniform(0.2, 1.0), 1.0
+                    grp = attr[i].value
+                vertex_colors[idx  ] = color
+                vertex_colors[idx+1] = color
+                vertex_colors[idx+2] = color
+                idx += 3
+
+            shader = gpu.shader.from_builtin('FLAT_COLOR')
+            batch = batch_for_shader(
+                shader, 'TRIS',
+                {"pos": vertices, "color": vertex_colors},
+                indices=indices,
+            )
+
+            # Draw the overlay over the existing collision object faces. There will be z-fighting as the object
+            # location falls further from the origin, which it especially does for map objects. Unfortunate, but
+            # probably fine for a simple visualization of the face groups.
+            gpu.state.depth_test_set('LESS_EQUAL')
+            gpu.state.depth_mask_set(True)
+            gpu.matrix.push()
+            gpu.matrix.multiply_matrix(bpy.context.active_object.matrix_local)
+            batch.draw(shader)
+            gpu.matrix.pop()
+            gpu.state.depth_mask_set(False)
+
+    draw_facegroups : bpy.props.BoolProperty(
+        name="Draw Face Groups",
+        description="Display the Face Groups of the active object (if found)",
+        default=False
+    )
+
+    #######################################################
     def register():
         bpy.types.Scene.dff = bpy.props.PointerProperty(type=DFFSceneProps)
 
@@ -102,3 +164,6 @@ class MapImportPanel(bpy.types.Panel):
 
         row = layout.row()
         row.operator("scene.dragonff_map_import")
+
+        layout.separator()
+        layout.prop(settings, "draw_facegroups", text="Display Face Groups")

--- a/gui/map.py
+++ b/gui/map.py
@@ -71,8 +71,11 @@ class DFFSceneProps(bpy.types.PropertyGroup):
         if not bpy.context.scene.dff.draw_facegroups:
             return
         o = bpy.context.active_object
-        if o and o.type == 'MESH' and o.data.attributes.get('face group'):
+        if o and o.select_get() and o.type == 'MESH' and o.data.attributes.get('face group'):
             mesh = bpy.context.active_object.data
+            attr = mesh.attributes['face group'].data
+            if len(attr) == 0:
+                return
             mesh.calc_loop_triangles()
 
             # As the face groups are stored as face attributes, we'll generate unique vertices across the whole overlay
@@ -88,7 +91,6 @@ class DFFSceneProps(bpy.types.PropertyGroup):
             color = []
             grp = -1
             idx = 0
-            attr = mesh.attributes['face group'].data
             for i, face in enumerate(mesh.loop_triangles):
                 vertices[idx  ] = mesh.vertices[face.vertices[0]].co
                 vertices[idx+1] = mesh.vertices[face.vertices[1]].co

--- a/gui/map.py
+++ b/gui/map.py
@@ -67,6 +67,25 @@ class DFFSceneProps(bpy.types.PropertyGroup):
     #     subtype = 'DIR_PATH'
     #     )
 
+    face_group_min : bpy.props.IntProperty(
+        name = 'Face Group Minimum Size',
+        default = 20,
+        min = 5,
+        max = 200
+    )
+
+    face_group_max : bpy.props.IntProperty(
+        name = 'Face Group Maximum Size',
+        default = 50,
+        min = 5,
+        max = 200
+    )
+
+    face_group_avoid_smalls : bpy.props.BoolProperty(
+        name = "Avoid overly small groups",
+        default = True
+    )
+
     def draw_fg():
         if not bpy.context.scene.dff.draw_facegroups:
             return

--- a/gui/map.py
+++ b/gui/map.py
@@ -67,8 +67,15 @@ class DFFSceneProps(bpy.types.PropertyGroup):
     #     subtype = 'DIR_PATH'
     #     )
 
+    draw_facegroups : bpy.props.BoolProperty(
+        name="Draw Face Groups",
+        description="Display the Face Groups of the active object (if they exist) in the viewport",
+        default=False
+    )
+
     face_group_min : bpy.props.IntProperty(
         name = 'Face Group Minimum Size',
+        description="Don't generate groups below this size",
         default = 20,
         min = 5,
         max = 200
@@ -76,6 +83,7 @@ class DFFSceneProps(bpy.types.PropertyGroup):
 
     face_group_max : bpy.props.IntProperty(
         name = 'Face Group Maximum Size',
+        description="Don't generate groups above this size (minimum size overrides this if larger)",
         default = 50,
         min = 5,
         max = 200
@@ -83,6 +91,7 @@ class DFFSceneProps(bpy.types.PropertyGroup):
 
     face_group_avoid_smalls : bpy.props.BoolProperty(
         name = "Avoid overly small groups",
+        description="Combine really small groups with their neighbor to avoid pointless isolated groups",
         default = True
     )
 
@@ -140,12 +149,6 @@ class DFFSceneProps(bpy.types.PropertyGroup):
             gpu.matrix.pop()
             gpu.state.depth_mask_set(False)
 
-    draw_facegroups : bpy.props.BoolProperty(
-        name="Draw Face Groups",
-        description="Display the Face Groups of the active object (if found)",
-        default=False
-    )
-
     #######################################################
     def register():
         bpy.types.Scene.dff = bpy.props.PointerProperty(type=DFFSceneProps)
@@ -185,6 +188,3 @@ class MapImportPanel(bpy.types.Panel):
 
         row = layout.row()
         row.operator("scene.dragonff_map_import")
-
-        layout.separator()
-        layout.prop(settings, "draw_facegroups", text="Display Face Groups")

--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -80,6 +80,11 @@ class col_exporter:
 
     #######################################################
     def _update_bounds(obj):
+
+        # Don't include shadow meshes in bounds calculations
+        if obj.dff.type == 'SHA':
+            return
+
         self = col_exporter
 
         if self.coll.bounds is None:
@@ -89,16 +94,25 @@ class col_exporter:
             ]
 
         dimensions = obj.dimensions
+        center = obj.location
             
         # Empties don't have a dimensions array
         if obj.type == 'EMPTY':
-            
-            # Multiplied by 2 because empty_display_size is a radius
-            dimensions = [
-                max(x * obj.empty_display_size * 2 for x in obj.scale)] * 3
-        
-        upper_bounds = [x + (y/2) for x, y in zip(obj.location, dimensions)]
-        lower_bounds = [x - (y/2) for x, y in zip(obj.location, dimensions)]
+
+            if obj.empty_display_type == 'SPHERE':
+                # Multiplied by 2 because empty_display_size is a radius
+                dimensions = [
+                    max(x * obj.empty_display_size * 2 for x in obj.scale)] * 3
+            else:
+                dimensions = obj.scale
+
+        # And Meshes require their proper center to be calculated because their transform is identity
+        else:
+            local_center = sum((mathutils.Vector(b) for b in obj.bound_box), mathutils.Vector()) / 8.0
+            center = obj.matrix_world @ local_center
+
+        upper_bounds = [x + (y/2) for x, y in zip(center, dimensions)]
+        lower_bounds = [x - (y/2) for x, y in zip(center, dimensions)]
 
         self.coll.bounds = [
             [max(x, y) for x,y in zip(self.coll.bounds[0], upper_bounds)],
@@ -112,11 +126,11 @@ class col_exporter:
         radius = 0.0
         center = [0, 0, 0]
         rect_min = [0, 0, 0]
-        rect_max  = [0, 0, 0]
+        rect_max = [0, 0, 0]
 
         if self.coll.bounds is not None:
             rect_min = self.coll.bounds[0]
-            rect_max  = self.coll.bounds[1]
+            rect_max = self.coll.bounds[1]
             center = [(x + y) / 2 for x, y in zip(*self.coll.bounds)]
             radius = (
                 mathutils.Vector(rect_min) - mathutils.Vector(rect_max)

--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -151,6 +151,27 @@ class col_exporter:
         pass
                 
     #######################################################
+    def _process_boxes(obj):
+        self = col_exporter
+
+        min = col.TVector(*(obj.location - obj.scale))
+        max = col.TVector(*(obj.location + obj.scale))
+
+        surface = col.TSurface(
+            obj.dff.col_material,
+            obj.dff.col_flags,
+            obj.dff.col_brightness,
+            obj.dff.col_light
+        )
+
+        self.coll.boxes.append(col.TBox(min=min,
+                                        max=max,
+                                        surface=surface,
+        ))
+
+        pass
+
+    #######################################################
     def _process_obj(obj):
         self = col_exporter
         
@@ -169,8 +190,11 @@ class col_exporter:
                 )
                     
         elif obj.type == 'EMPTY':
-            self._process_spheres(obj)
-        
+            if obj.empty_display_type == 'SPHERE':
+                self._process_spheres(obj)
+            else:
+                self._process_boxes(obj)
+
         self._update_bounds(obj)
         
     

--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -216,7 +216,7 @@ def export_col(options):
     if options['mass_export']:
         output = b'';
         
-        root_collection = bpy.context.scene.collection
+        root_collection = bpy.context.scene.collection if col_exporter.collection is None else col_exporter.collection
         collections = root_collection.children.values() + [root_collection]
         col_exporter.memory = True
 

--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -59,7 +59,7 @@ class col_exporter:
         for i, face in enumerate(bm.faces):
 
             # Face Groups
-            if layer:
+            if layer and col.Sections.version > 1:
                 lastface = i == len(bm.faces)-1
                 idx = face[layer]
 
@@ -253,9 +253,14 @@ class col_exporter:
         self.coll.version = self.version
         self.coll.model_name = os.path.basename(name)
 
+        bounds_found = False
         objects = bpy.data.objects
         if self.collection is not None:
             objects = self.collection.objects
+            # Get original import bounds from collection (some collisions come in as just bounds with no other items)
+            if self.collection.get('bounds min') and self.collection.get('bounds max'):
+                bounds_found = True
+                self.coll.bounds = [self.collection['bounds min'], self.collection['bounds max']]
 
         total_objects = 0
         for obj in objects:
@@ -267,7 +272,7 @@ class col_exporter:
         self._convert_bounds()
         
         if self.memory:
-            if total_objects > 0:
+            if total_objects > 0 or bounds_found:
                 return col.coll(self.coll).write_memory()
             return b''
 

--- a/ops/col_importer.py
+++ b/ops/col_importer.py
@@ -200,6 +200,11 @@ class col_importer:
                                                            model.model_name),
                                            link
             )            
+
+            # Store the import bounds as a custom property of the collection
+            collection['bounds min'] = model.bounds[0]
+            collection['bounds max'] = model.bounds[1]
+
             self.__add_spheres(collection, model.spheres)
             self.__add_boxes(collection, model.boxes)
 

--- a/ops/col_importer.py
+++ b/ops/col_importer.py
@@ -171,7 +171,7 @@ class col_importer:
             except Exception as e:
                 print(e)
                 
-            bm.to_mesh(mesh)
+        bm.to_mesh(mesh)
         
         obj = bpy.data.objects.new(name, mesh)
         obj.dff.type = 'SHA' if shadow else 'COL'

--- a/ops/col_importer.py
+++ b/ops/col_importer.py
@@ -48,27 +48,20 @@ class col_importer:
         return col_importer(collision)
     
     #######################################################
-    def __add_shapes(self, collection, array, sphere=True):
+    def __add_spheres(self, collection, array):
 
         for index, entity in enumerate(array):
-            name = collection.name + (".Sphere.%d" if sphere else ".Box.%d") % (index)
+            name = collection.name + ".ColSphere.%d" % index
         
-            obj  = bpy.data.objects.new(name, None)
+            obj = bpy.data.objects.new(name, None)
 
-            if sphere:
-                obj.location = entity.center
-                obj.scale = [entity.radius] * 3
-            else:
-                min = mathutils.Vector(entity.min)
-                max = mathutils.Vector(entity.max)
-                half = 0.5 * (max - min)
-                obj.location = min + half
-                obj.scale = half
+            obj.location = entity.center
+            obj.scale = [entity.radius] * 3
 
             if (2, 80, 0) > bpy.app.version:
-                obj.empty_draw_type = 'SPHERE' if sphere else 'CUBE'
+                obj.empty_draw_type = 'SPHERE'
             else:
-                obj.empty_display_type = 'SPHERE' if sphere else 'CUBE'
+                obj.empty_display_type = 'SPHERE'
 
             obj.dff.type = 'COL'
             obj.dff.col_material = entity.surface.material
@@ -76,6 +69,33 @@ class col_importer:
             obj.dff.col_brightness = entity.surface.brightness
             obj.dff.col_light = entity.surface.light
             
+            link_object(obj, collection)
+
+    #######################################################
+    def __add_boxes(self, collection, array):
+
+        for index, entity in enumerate(array):
+            name = collection.name + ".ColBox.%d" % index
+
+            obj = bpy.data.objects.new(name, None)
+
+            mn = mathutils.Vector(entity.min)
+            mx = mathutils.Vector(entity.max)
+            half = 0.5 * (mx - mn)
+            obj.location = mn + half
+            obj.scale = half
+
+            if (2, 80, 0) > bpy.app.version:
+                obj.empty_draw_type = 'CUBE'
+            else:
+                obj.empty_display_type = 'CUBE'
+
+            obj.dff.type = 'COL'
+            obj.dff.col_material = entity.surface.material
+            obj.dff.col_flags = entity.surface.flags
+            obj.dff.col_brightness = entity.surface.brightness
+            obj.dff.col_light = entity.surface.light
+
             link_object(obj, collection)
 
     #######################################################
@@ -171,8 +191,8 @@ class col_importer:
                                                            model.model_name),
                                            link
             )            
-            self.__add_shapes(collection, model.spheres)
-            self.__add_shapes(collection, model.boxes, False)
+            self.__add_spheres(collection, model.spheres)
+            self.__add_boxes(collection, model.boxes)
 
             if len(model.mesh_verts) > 0:
                 self.__add_mesh(collection,

--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -916,6 +916,13 @@ class dff_exporter:
         
         for obj in objects:
 
+            # Skip collision objects in the base collection. These are inside their own nested collection for singularly
+            # imported DFFs, but the map importer will put collision meshes inside the same collection as the map mesh
+            # object they represent. We can just ignore collision meshes here as the DFF exporter will still look for
+            # them in their own nested collection later if export_coll is true.
+            if obj.dff.type == 'COL':
+                continue
+
             # create atomic in this case
             if obj.type == "MESH":
                 self.populate_atomic(obj)

--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -286,6 +286,7 @@ class dff_exporter:
     collection = None
     export_coll = False
     exclude_geo_faces = False
+    from_outliner = False
 
     #######################################################
     @staticmethod
@@ -973,9 +974,14 @@ class dff_exporter:
             collections = [bpy.data]
 
         else:
-            root_collection = bpy.context.scene.collection
-            collections = root_collection.children.values() + [root_collection]
-            
+            if self.from_outliner:
+                collections = [bpy.context.view_layer.objects.active.users_collection[0]]
+            else:
+                collections = []
+                for collection in bpy.data.collections:
+                    if collection.name.endswith(".dff"):
+                        collections.append(collection)
+
         for collection in collections:
             for obj in collection.objects:
                     
@@ -1008,5 +1014,6 @@ def export_dff(options):
     dff_exporter.path               = options['directory']
     dff_exporter.version            = options['version']
     dff_exporter.export_coll        = options['export_coll']
+    dff_exporter.from_outliner      = options['from_outliner']
 
     dff_exporter.export_dff(options['file_name'])

--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -276,6 +276,7 @@ class dff_exporter:
 
     selected = False
     mass_export = False
+    preserve_positions = True
     file_name = ""
     dff = None
     version = None
@@ -321,7 +322,7 @@ class dff_exporter:
 
         frame.creation_flags  =  0
         frame.parent          = -1
-        frame.position        = matrix.to_translation()
+        frame.position        = matrix.to_translation() if self.preserve_positions else (0, 0, 0)
         frame.rotation_matrix = dff.Matrix._make(
             matrix.to_3x3().transposed()
         )
@@ -1003,6 +1004,7 @@ def export_dff(options):
     dff_exporter.export_frame_names = options['export_frame_names']
     dff_exporter.exclude_geo_faces  = options['exclude_geo_faces']
     dff_exporter.mass_export        = options['mass_export']
+    dff_exporter.preserve_positions = options['preserve_positions']
     dff_exporter.path               = options['directory']
     dff_exporter.version            = options['version']
     dff_exporter.export_coll        = options['export_coll']

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -215,7 +215,7 @@ class Map_Import_Operator(bpy.types.Operator):
 
         # Get all the col files from dff folder with the same region prefix as the current map section
         if self.settings.load_collisions:
-            region_prefix = self.settings.map_sections[:-4].split('\\')[-1].split("_")[0].lower()
+            region_prefix = self.settings.map_sections[:-4].split('/')[-1].split("_")[0].lower()
             for filename in os.listdir(self.settings.dff_folder):
                 if filename.endswith(".col") and filename.startswith(region_prefix):
                     if bpy.data.collections.get(filename):

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -214,14 +214,15 @@ class Map_Import_Operator(bpy.types.Operator):
         self._object_data = map_data['object_data']
 
         # Get all the col files from dff folder with the same region prefix as the current map section
-        region_prefix = self.settings.map_sections[:-4].split('\\')[-1].split("_")[0].lower()
-        for filename in os.listdir(self.settings.dff_folder):
-            if filename.endswith(".col") and filename.startswith(region_prefix):
-                if bpy.data.collections.get(filename):
-                    print("%s already loaded" % filename)
-                    continue
-                self._col_files.append(filename)
-        self._col_files_to_load = len(self._col_files)
+        if self.settings.load_collisions:
+            region_prefix = self.settings.map_sections[:-4].split('\\')[-1].split("_")[0].lower()
+            for filename in os.listdir(self.settings.dff_folder):
+                if filename.endswith(".col") and filename.startswith(region_prefix):
+                    if bpy.data.collections.get(filename):
+                        print("%s already loaded" % filename)
+                        continue
+                    self._col_files.append(filename)
+            self._col_files_to_load = len(self._col_files)
 
         wm = context.window_manager
         wm.progress_begin(0, 100.0)

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -205,7 +205,7 @@ class Map_Import_Operator(bpy.types.Operator):
             else:
                 # As the number of objects increases, loading performance starts to get crushed by scene updates, so
                 # we try to keep loading at least 5% of the total scene object count on each timer pulse.
-                num_objects_at_once = max(1, int(0.05 * len(bpy.data.objects)))
+                num_objects_at_once = max(10, int(0.05 * len(bpy.data.objects)))
 
                 # Now load the actual objects
                 for x in range(num_objects_at_once):

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -36,6 +36,7 @@ class Map_Import_Operator(bpy.types.Operator):
     _model_cache = {}
     _col_files = []
     _col_files_to_load = 0
+    ipl_collection = None
 
     settings = None
 
@@ -118,6 +119,10 @@ class Map_Import_Operator(bpy.types.Operator):
                 Map_Import_Operator.apply_transformation_to_object(
                     importer.objects[0], inst
                 )
+
+            # Move dff collection to a top collection named for the file it came from
+            bpy.context.scene.collection.children.unlink(importer.current_collection)
+            self.ipl_collection.children.link(importer.current_collection)
 
             # Save into buffer
             self._model_cache[inst.id] = importer.objects
@@ -212,6 +217,10 @@ class Map_Import_Operator(bpy.types.Operator):
         
         self._object_instances = map_data['object_instances']
         self._object_data = map_data['object_data']
+
+        # Create a top level collection to hold all the subsequent dffs loaded from this map section
+        self.ipl_collection = bpy.data.collections.new(self.settings.map_sections)
+        bpy.context.scene.collection.children.link(self.ipl_collection)
 
         # Get all the col files from dff folder with the same region prefix as the current map section
         if self.settings.load_collisions:

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -137,6 +137,7 @@ class Map_Import_Operator(bpy.types.Operator):
         for obj in bpy.data.objects:
             if obj.dff.type == 'COL' and obj.name.endswith("%s.ColMesh" % name):
                 new_obj = bpy.data.objects.new(obj.name, obj.data)
+                new_obj.dff.type = 'COL'
                 new_obj.location = obj.location
                 new_obj.rotation_quaternion = obj.rotation_quaternion
                 new_obj.scale = obj.scale


### PR DESCRIPTION
Hi there. I'm looking to add collisions to the map importer here. As well as a convenient way to mass export back to their container files. The map collisions are stored in a series of col files inside gta3.img but I just look for them in the dff extract folder. I think the commit comments explain it well enough but here are a few screen shots. Anyway I'm still new to collaboration on git so I just wanted to start a discussion on this while I worked on it.
Here's the shortcut to export all collisions back to their container.
![Screenshot_1](https://github.com/Parik27/DragonFF/assets/728467/b7753598-518e-4772-a34c-864163c076ef)
And here's a map piece with its collision sitting on top of it (and z-fighting). The collisions are hidden on import, but you can edit them in-place this way.![Screenshot_2](https://github.com/Parik27/DragonFF/assets/728467/6372c40e-d340-4257-bdb2-946cc988a579)
I'd also like to re-arrange each map section to a top-level collection named for the ipl file from which it came. That will organize the scene better. What do you think?