### PR TITLE
Import TXD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The following is a list of supported features by the addon
 
 - [X] Model files
 - [ ] Texture Files
+  - [X] Import *(Partial, experimental)*
+  - [ ] Export
 - [X] Collision files (including the ones packed in dff)
   - [X] Import
   - [X] Export *(Partial)*
@@ -46,7 +48,7 @@ The python scripts have been designed with reusability in mind. As of now, the d
 #### Standalone Modules
 
 * [X] - DFF - `dff.py`
-* [ ] - TXD - `txd.py`
+* [X] - TXD - `txd.py` (partial, experimental)
 * [X] - COL - `col.py`
 * [X] - IPL/IDE - `map.py` (partial, experimental)
 * [ ] - IFP - `ifp.py`

--- a/gtaLib/dff.py
+++ b/gtaLib/dff.py
@@ -40,6 +40,9 @@ DualFX      = namedtuple("DualFX"      , "src_blend dst_blend texture")
 ReflMat     = namedtuple("ReflMat"     , "s_x s_y o_x o_y intensity")
 SpecularMat = namedtuple("SpecularMap" , "level texture")
 
+TexDict = namedtuple("TexDict", "texture_count device_id")
+PITexDict = namedtuple("PITexDict", "texture_count device_id")
+
 UserDataSection = namedtuple("UserDataSection", "name data")
 
 # geometry flags
@@ -101,9 +104,13 @@ types = {
     "Geometry"                : 15,
     "Clump"                   : 16,
     "Atomic"                  : 20,
+    "Texture Native"          : 21,
+    "Texture Dictionary"      : 22,
+    "Image"                   : 24,
     "Geometry List"           : 26,
     "Animation Anim"          : 27,
     "Right to Render"         : 31,
+    "PI Texture Dictionary"   : 35,
     "UV Animation Dictionary" : 43,
     "Morph PLG"               : 261,
     "Skin PLG"                : 278,
@@ -156,7 +163,10 @@ class Sections:
         Atomic      : "<4I",
         TexCoords   : "<2f",
         ReflMat     : "<5f4x",
-        SpecularMat : "<f24s"
+        SpecularMat : "<f24s",
+
+        TexDict : "<2H",
+        PITexDict: "<2H"
     }
 
     library_id = 0 # used for writing

--- a/gtaLib/txd.py
+++ b/gtaLib/txd.py
@@ -565,14 +565,14 @@ class txd:
         self._read(pixels_len)
 
         # Palette
-        pallate_len = 0
+        palette_len = 0
         if image.depth == 8:
-            pallate_len = 1024
+            palette_len = 1024
         elif image.depth == 4:
-            pallate_len = 64
+            palette_len = 64
 
-        image.palette = self.raw(pallate_len)
-        self._read(pallate_len)
+        image.palette = self.raw(palette_len)
+        self._read(palette_len)
 
         return image
 

--- a/gtaLib/txd.py
+++ b/gtaLib/txd.py
@@ -14,105 +14,682 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from struct import unpack_from, calcsize, pack
+from enum import IntEnum
+from math import ceil
+from struct import unpack_from
 from collections import namedtuple
 
+from .dff import Sections, NativePlatformType
+from .dff import types, Chunk, TexDict, PITexDict, Texture
+from .dff import strlen
+
+class RasterFormat(IntEnum):
+    RASTER_DEFAULT = 0x00
+    RASTER_1555    = 0x01
+    RASTER_565     = 0x02
+    RASTER_4444    = 0x03
+    RASTER_LUM     = 0x04
+    RASTER_8888    = 0x05
+    RASTER_888     = 0x06
+    RASTER_555     = 0x0a
+
+#######################################################
+class ImageDecoder:
+
+    @staticmethod
+    def _decode1555(bits):
+        a = ((bits >> 15) & 0x1) * 0xff
+        b = ((bits >> 10) & 0x1f) << 3
+        c = ((bits >> 5) & 0x1f) << 3
+        d = (bits & 0x1f) << 3
+        return a, b, c, d
+
+    @staticmethod
+    def _decode4444(bits):
+        a = ((bits >> 12) & 0xf) << 4
+        b = ((bits >> 8) & 0xf) << 4
+        c = ((bits >> 4) & 0xf) << 4
+        d = (bits & 0xf) << 4
+        return a, b, c, d
+
+    @staticmethod
+    def _decode565(bits):
+        a = ((bits >> 11) & 0x1f) << 3
+        b = ((bits >> 5) & 0x3f) << 2
+        c = (bits & 0x1f) << 3
+        return a, b, c
+
+    @staticmethod
+    def _decode555(bits):
+        a = ((bits >> 10) & 0x1f) << 3
+        b = ((bits >> 5) & 0x1f) << 3
+        c = (bits & 0x1f) << 3
+        return a, b, c
+
+    @staticmethod
+    def _c2a(a, b):
+        return (2 * a + b) // 3
+
+    @staticmethod
+    def _c2b(a, b):
+        return (a + b) // 2
+
+    @staticmethod
+    def _c3(a, b):
+        return (2 * b + a) // 3
+
+    @staticmethod
+    def dxt1(data, width, height, alpha_flag):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for y in range(0, height, 4):
+            for x in range(0, width, 4):
+                color0, color1, bits = unpack_from("<HHI", data, pos)
+                pos += 8
+
+                r0, g0, b0 = ImageDecoder._decode565(color0)
+                r1, g1, b1 = ImageDecoder._decode565(color1)
+
+                # Decode this block into 4x4 pixels
+                for j in range(4):
+                    for i in range(4):
+                        # Get next control op and generate a pixel
+                        control = bits & 3
+                        bits = bits >> 2
+                        if control == 0:
+                            r, g, b, a = r0, g0, b0, 0xff
+                        elif control == 1:
+                            r, g, b, a = r1, g1, b1, 0xff
+                        elif control == 2:
+                            if color0 > color1:
+                                r, g, b, a = ImageDecoder._c2a(r0, r1), ImageDecoder._c2a(g0, g1), ImageDecoder._c2a(b0, b1), 0xff
+                            else:
+                                r, g, b, a = ImageDecoder._c2b(r0, r1), ImageDecoder._c2b(g0, g1), ImageDecoder._c2b(b0, b1), 0xff
+                        elif control == 3:
+                            if color0 > color1:
+                                r, g, b, a = ImageDecoder._c3(r0, r1),ImageDecoder. _c3(g0, g1), ImageDecoder._c3(b0, b1), 0xff
+                            else:
+                                r, g, b, a = 0, 0, 0, 0
+
+                        idx = 4 * ((y + j) * width + (x + i))
+                        ret[idx:idx+4] = bytes([r, g, b, a | alpha_flag])
+
+        return bytes(ret)
+
+    @staticmethod
+    def dxt3(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for y in range(0, height, 4):
+            for x in range(0, width, 4):
+                alpha0, alpha1, alpha2, alpha3, color0, color1, bits = unpack_from("<4H2HI", data, pos)
+                pos += 16
+
+                r0, g0, b0 = ImageDecoder._decode565(color0)
+                r1, g1, b1 = ImageDecoder._decode565(color1)
+                alphas = (alpha0, alpha1, alpha2, alpha3)
+
+                # Decode this block into 4x4 pixels
+                for j in range(4):
+                    for i in range(4):
+                        # Get next control op and generate a pixel
+                        control = bits & 3
+                        bits = bits >> 2
+                        if control == 0:
+                            r, g, b = r0, g0, b0
+                        elif control == 1:
+                            r, g, b = r1, g1, b1
+                        elif control == 2:
+                            if color0 > color1:
+                                r, g, b = ImageDecoder._c2a(r0, r1), ImageDecoder._c2a(g0, g1), ImageDecoder._c2a(b0, b1)
+                            else:
+                                r, g, b = ImageDecoder._c2b(r0, r1), ImageDecoder._c2b(g0, g1), ImageDecoder._c2b(b0, b1)
+                        elif control == 3:
+                            if color0 > color1:
+                                r, g, b = ImageDecoder._c3(r0, r1),ImageDecoder. _c3(g0, g1), ImageDecoder._c3(b0, b1)
+                            else:
+                                r, g, b = 0, 0, 0
+
+                        a = ((alphas[j] >> (i * 4)) & 0xf) * 0x11
+                        idx = 4 * ((y + j) * width + (x + i))
+                        ret[idx:idx+4] = bytes([r, g, b, a])
+
+        return bytes(ret)
+
+    @staticmethod
+    def bgra1555(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for i in range(0, len(data), 2):
+            color = unpack_from("<H", data, i)[0]
+            a, r, g, b = ImageDecoder._decode1555(color)
+            ret[pos:pos+4] = r, g, b, a
+            pos += 4
+        return bytes(ret)
+
+    @staticmethod
+    def bgra4444(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for i in range(0, len(data), 2):
+            color = unpack_from("<H", data, i)[0]
+            a, r, g, b = ImageDecoder._decode4444(color)
+            ret[pos:pos+4] = r, g, b, a
+            pos += 4
+        return bytes(ret)
+
+    @staticmethod
+    def bgra555(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for i in range(0, len(data), 2):
+            color = unpack_from("<H", data, i)[0]
+            r, g, b = ImageDecoder._decode555(color)
+            ret[pos:pos+4] = r, g, b, 0xff
+            pos += 4
+        return bytes(ret)
+
+    @staticmethod
+    def bgra565(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for i in range(0, len(data), 2):
+            color = unpack_from("<H", data, i)[0]
+            r, g, b = ImageDecoder._decode565(color)
+            ret[pos:pos+4] = r, g, b, 0xff
+            pos += 4
+        return bytes(ret)
+
+    @staticmethod
+    def bgra888(data, width, height):
+        ret = bytearray(4 * width * height)
+        for i in range(0, len(data), 4):
+            ret[i:i+4] = data[i+2], data[i+1], data[i+0], 0xff
+        return bytes(ret)
+
+    @staticmethod
+    def bgra8888(data, width, height):
+        ret = bytearray(4 * width * height)
+        for i in range(0, len(data), 4):
+            ret[i:i+4] = data[i+2], data[i+1], data[i+0], data[i+3]
+        return bytes(ret)
+
+    @staticmethod
+    def lum8(data, width, height):
+        ret = bytearray(4 * width * height)
+        for i, c in enumerate(data):
+            pos = i * 4
+            ret[pos:pos+4] = c, c, c, 0xff
+        return bytes(ret)
+
+    @staticmethod
+    def lum8a8(data, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for i in range(0, len(data), 2):
+            c, a = data[i], data[i+1]
+            ret[pos:pos+4] = c, c, c, a
+            pos += 4
+        return bytes(ret)
+
+    @staticmethod
+    def pal4(data, palette, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        shift = 0
+        for i in data:
+            idx = (i >> shift) & 0xf
+            ret[pos+0:pos+4] = palette[idx*4:idx*4+4]
+            shift ^= 4
+            pos += 4
+
+        return bytes(ret)
+
+    @staticmethod
+    def pal8(data, palette, width, height):
+        pos = 0
+        ret = bytearray(4 * width * height)
+
+        for idx in data:
+            ret[pos:pos+4] = palette[idx*4:idx*4+4]
+            pos += 4
+
+        return bytes(ret)
+
+#######################################################
 class TextureNative:
 
     # Header
-    _platformId = 0
-    _filterMode = 0
+    _platform_id = 0
+    _filter_mode = 0
 
-    uAddressing = 0
-    vAddressing = 0
+    uv_addressing = 0
 
     name = ""
     mask = ""
 
-    format = []
-    width = 0
-    height = 0
-    depth = 0
-    numLevels = 0
-    rasterType = 0
+    raster_format = 0
+    width         = 0
+    height        = 0
+    depth         = 0
+    num_levels    = 0
+    raster_type   = 0
 
     image_properties = None
 
     # Palette
-    hasPalette = False
-    palette = []
+    palette = b''
 
     # Raster Data
-    _data = []
+    pixels = b''
 
     #######################################################
-    def read_image_properties(platformId, data, offset):
+    def to_rgba(self, level=0):
+        width  = self.get_width(level)
+        height = self.get_height(level)
+        pixels = self.pixels[level]
+
+        if self.palette:
+            palette_format = self.raster_format & 0xf000
+
+            if palette_format > 0:
+                if palette_format == 0x2000:
+                    return ImageDecoder.pal8(pixels, self.palette, width, height)
+                elif palette_format == 0x4000:
+                    if self.depth == 4:
+                        return ImageDecoder.pal4(pixels, self.palette, width, height)
+                    else:
+                        return ImageDecoder.pal8(pixels, self.palette, width, height)
+
+        else:
+            # TODO: improve format definition
+            pixels_format = (self.raster_format >> 8) & 0x0f
+
+            if self.image_properties.compressed:
+                if pixels_format == RasterFormat.RASTER_DEFAULT:
+                    return ImageDecoder.lum8a8(pixels, width, height)
+                if pixels_format == RasterFormat.RASTER_1555:
+                    return ImageDecoder.dxt1(pixels, width, height, 0x00)
+                elif pixels_format == RasterFormat.RASTER_565:
+                    return ImageDecoder.dxt1(pixels, width, height, 0xff)
+                elif pixels_format == RasterFormat.RASTER_4444:
+                    return ImageDecoder.dxt3(pixels, width, height)
+            else:
+                if pixels_format == RasterFormat.RASTER_1555:
+                    # return ImageDecoder.bgra1555(pixels, width, height)
+                    return ImageDecoder.dxt1(pixels, width, height, 0x00)
+                elif pixels_format == RasterFormat.RASTER_565:
+                    # return ImageDecoder.bgra565(pixels, width, height)
+                    return ImageDecoder.dxt1(pixels, width, height, 0xff)
+                elif pixels_format == RasterFormat.RASTER_4444:
+                    # return ImageDecoder.bgra4444(pixels, width, height)
+                    return ImageDecoder.dxt3(pixels, width, height)
+                elif pixels_format == RasterFormat.RASTER_LUM:
+                    return ImageDecoder.lum8(pixels, width, height)
+                elif pixels_format == RasterFormat.RASTER_8888:
+                    return ImageDecoder.bgra8888(pixels, width, height)
+                elif pixels_format == RasterFormat.RASTER_888:
+                    return ImageDecoder.bgra888(pixels, width, height)
+                elif pixels_format == RasterFormat.RASTER_555:
+                    return ImageDecoder.bgra555(pixels, width, height)
+
+    #######################################################
+    def get_width(self, level=0):
+        return max(self.width >> level, 1)
+
+    #######################################################
+    def get_height(self, level=0):
+        return max(self.height >> level, 1)
+
+    #######################################################
+    def read_pixels(self, data, offset):
+        pixels_len = unpack_from("<I", data, offset)[0]
+        return data[offset+4:offset+4+pixels_len]
+
+    #######################################################
+    def read_palette(self, data, offset):
+        palette_format = self.raster_format & 0xf000
+
+        if palette_format > 0:
+            if palette_format == 0x2000:
+                return data[offset:offset+1024]
+
+            if palette_format == 0x4000:
+                if self.depth == 4:
+                    return data[offset:offset+64]
+
+                return data[offset:offset+128]
+
+        return b''
+
+    #######################################################
+    def read_image_properties(self, data, offset):
 
         ImageProperties = namedtuple(
             "ImageProperties",
-            "alpha", "cubeTexture", "autoMipMaps", "compressed", "compression"
-        )
-
-        # San Andreas
-        if platformId == 9:
-
-            props = unpack_from("<I4x", data, offset)
-            return ImageProperties(props[0] & 0b0001 != 0,
-                                   props[0] & 0b0010 != 0,
-                                   props[0] & 0b0100 != 0,
-                                   props[0] & 0b1000 != 0
-                                   -1)
-
-        # Vice City, GTA 3
-        elif platformId == 8:
-
-            compression = unpack_from("<B", data, offset)
-            return ImageProperties(False, False, False, False, compression)
-    
-    #######################################################
-    def _from_mem_pc(self, data):
-
-        TextureFormat = namedtuple(
-            "Header",
             [
-                'platformId' , 'filterMode' , 'uvAddressing' ,
-                'name'       , 'maskName']
+                "alpha", "cube_texture", "auto_mipmaps",
+                "compressed"]
         )
 
-        RasterFormat  = namedtuple(
-            "RasterFormat",
-            [
-                'rasterFormat' , 'sa_format_3vc_hasAlpha'   , 'width'     ,
-                'height'       ,  'depth'                   , 'numLevels' ,
-                'rasterType'   , 'image_properties'
-            ]
-        )
+        prop = unpack_from("<B", data, offset)[0]
+        return ImageProperties(prop & 0b0001 != 0,
+                               prop & 0b0010 != 0,
+                               prop & 0b0100 != 0,
+                               prop & 0b1000 != 0)
 
-        pos = 0
-        tex_format = TextureFormat._make(unpack_from("<IHH16x32s32s", data, pos))
-        pos += 88
-
-        (
-            self._platformId, self._filterMode, self.uAddressing, self.name,
-            self.mask
-        ) = tex_format
-
-        self.name = self.name.decode('ascii')
-        self.mask = self.mask.decode('ascii')
-
-        
-        raster_format = RasterFormat(
-            *unpack_from("<IIHHbbb", pos),
-            self.read_image_properties(data, pos + 15)
-        )
-    
     #######################################################
     def from_mem(data):
 
         self = TextureNative()
-        platformId = unpack_from("<I", data)[0]
-        
-        if platformId == 8 or platformId == 9 or platformId == 5:
-            self._from_mem_pc(data)
-    
-    pass
+
+        TextureFormat = namedtuple(
+            "Header",
+            [
+                'platform_id' , 'filter_mode' , 'uv_addressing' ,
+                'name'        , 'mask_name']
+        )
+
+        RasterHeader  = namedtuple(
+            "RasterHeader",
+            [
+                'raster_format' , 'sa_format_3vc_hasAlpha' , 'width'      ,
+                'height'        , 'depth'                  , 'num_levels' ,
+                'raster_type'   , 'image_properties']
+        )
+
+        pos = 0
+        tex_format = TextureFormat._make(unpack_from("<IHH32s32s", data, pos))
+        pos += 72
+
+        (
+            self._platform_id, self._filter_mode, self.uv_addressing, self.name,
+            self.mask
+        ) = tex_format
+
+        self.name = self.name.decode("utf-8").replace('\0', '')
+        try:
+            self.mask = self.mask.decode("utf-8").replace('\0', '')
+        except UnicodeDecodeError:
+            self.mask = ''
+
+        raster_header = RasterHeader(
+            *unpack_from("<IIHHBBB", data, pos),
+            self.read_image_properties(data, pos + 15)
+        )
+        pos += 16
+
+        (
+            self.raster_format, sa_format_3vc_hasAlpha, self.width, self.height,
+            self.depth, self.num_levels, self.raster_type, self.image_properties
+        ) = raster_header
+
+        self.palette = self.read_palette(data, pos)
+        pos += len(self.palette)
+
+        self.pixels = []
+        for _ in range(self.num_levels):
+            pixels = self.read_pixels(data, pos)
+            self.pixels.append(pixels)
+            pos += 4 + len(pixels)
+
+        return self
+
+#######################################################
+class Image:
+
+    width = 0
+    height = 0
+    depth = 0
+    pitch = 0
+
+    # Palette
+    palette = b''
+
+    # Raster Data
+    pixels = b''
+
+    #######################################################
+    def _crop_pixels(self):
+        src_width = len(self.pixels) // self.height
+        dst_width = ceil(self.width * self.depth / 8)
+
+        if src_width == dst_width:
+            return self.pixels
+
+        pixels = bytearray(dst_width * self.height)
+
+        for y in range(self.height):
+            src_pos = y * src_width
+            dst_pos = y * dst_width
+            pixels[dst_pos:dst_pos+dst_width] = self.pixels[src_pos:src_pos+src_width]
+
+        return bytes(pixels)
+
+    #######################################################
+    def to_rgba(self, level=0):
+        pixels = self._crop_pixels()
+
+        if self.depth == 32:
+            return ImageDecoder.bgra8888(pixels, self.width, self.height)
+        elif self.depth == 8:
+            return ImageDecoder.pal8(pixels, self.palette, self.width, self.height)
+        elif self.depth == 4:
+            return ImageDecoder.pal4(pixels, self.palette, self.width, self.height)
+
+    #######################################################
+    def from_mem(data):
+        self = Image()
+
+        self.width, self.height, self.depth, self.pitch = unpack_from("<4I", data)
+
+        return self
+
+#######################################################
+class txd:
+
+    #######################################################
+    def _read(self, size):
+        current_pos = self.pos
+        self.pos += size
+
+        return current_pos
+
+    #######################################################
+    def raw(self, size, offset=None):
+
+        if offset is None:
+            offset = self.pos
+
+        return self.data[offset:offset+size]
+
+    #######################################################
+    def read_chunk(self):
+        chunk = Sections.read(Chunk, self.data, self._read(12))
+        return chunk
+
+    #######################################################
+    def read_texture_native(self, parent_chunk):
+
+        chunk_end = self.pos + parent_chunk.size
+
+        while self.pos < chunk_end:
+            chunk = self.read_chunk()
+
+            # STRUCT
+            if chunk.type == types["Struct"]:
+                platform_id = unpack_from("<I", self.data, self.pos)[0]
+
+                # TODO: PS2
+                if self.device_id == 0:
+                    if platform_id in (NativePlatformType.XBOX, NativePlatformType.D3D8, NativePlatformType.D3D9):
+                        texture = TextureNative.from_mem(
+                                self.data[self.pos:self.pos+chunk.size]
+                        )
+                        self.native_textures.append(texture)
+
+                elif self.device_id in (1, 2):
+                    texture = TextureNative.from_mem(
+                            self.data[self.pos:self.pos+chunk.size]
+                    )
+                    self.native_textures.append(texture)
+
+            elif chunk.type == types["Extension"]:
+                pass
+
+            self._read(chunk.size)
+
+    #######################################################
+    def read_image(self, parent_chunk):
+
+        chunk = self.read_chunk()
+
+        # Read an image
+        image = Image.from_mem(
+            self.data[self.pos:self.pos+chunk.size]
+        )
+
+        self._read(chunk.size)
+
+        # Pixels
+        pixels_len = image.pitch * image.height
+        image.pixels = self.raw(pixels_len)
+        self._read(pixels_len)
+
+        # Palette
+        pallate_len = 0
+        if image.depth == 8:
+            pallate_len = 1024
+        elif image.depth == 4:
+            pallate_len = 64
+
+        image.palette = self.raw(pallate_len)
+        self._read(pallate_len)
+
+        return image
+
+    #######################################################
+    def read_texture(self, parent_chunk):
+
+        chunk = self.read_chunk()
+
+        # Read a texture
+        texture = Texture.from_mem(
+            self.data[self.pos:self.pos+chunk.size]
+        )
+
+        self._read(chunk.size)
+
+        # Texture Name
+        chunk = self.read_chunk()
+        texture.name = self.raw(
+            strlen(self.data, self.pos)
+        ).decode("utf-8")
+
+        self._read(chunk.size)
+
+        # Mask Name
+        chunk = self.read_chunk()
+        texture.mask = self.raw(
+            strlen(self.data, self.pos)
+        ).decode("utf-8")
+
+        self._read(chunk.size)
+
+        return texture
+
+    #######################################################
+    def read_texture_dictionary(self, root_chunk):
+
+        chunk_end = self.pos + root_chunk.size
+
+        while self.pos < chunk_end:
+            chunk = self.read_chunk()
+
+            # STRUCT
+            if chunk.type == types["Struct"]:
+
+                text_dict = Sections.read(TexDict, self.data, self._read(chunk.size))
+                self.device_id = text_dict.device_id # 1 for D3D8, 2 for D3D9, 6 for PlayStation 2, 8 for XBOX, 9 for PSP
+
+                for _ in range(text_dict.texture_count):
+                    chunk = self.read_chunk()
+
+                    # TEXTURENATIVE
+                    if chunk.type == types["Texture Native"]:
+                        self.read_texture_native(chunk)
+
+            else:
+                self._read(chunk.size)
+
+    #######################################################
+    def read_pi_texture_dictionary(self, root_chunk):
+        text_dict = Sections.read(TexDict, self.data, self._read(4))
+        self.device_id = text_dict.device_id
+
+        for _ in range(text_dict.texture_count):
+            mips_num = unpack_from("<I", self.data, self._read(4))[0]
+            images = []
+
+            for _ in range(mips_num):
+                chunk = self.read_chunk()
+                if chunk.type != types["Image"]:
+                    raise RuntimeError("Invalid format")
+
+                images.append(self.read_image(chunk))
+
+            self.images.append(images)
+
+            chunk = self.read_chunk()
+            if chunk.type != types["Texture"]:
+                raise RuntimeError("Invalid format")
+
+            texture = self.read_texture(chunk)
+            self.textures.append(texture)
+
+            chunk = self.read_chunk()
+            if chunk.type != types["Extension"]:
+                raise RuntimeError("Invalid format")
+
+            self._read(chunk.size)
+
+    #######################################################
+    def load_memory(self, data):
+        self.data = data
+
+        chunk = self.read_chunk()
+        if chunk.type == types["Texture Dictionary"]:
+            self.read_texture_dictionary(chunk)
+        elif chunk.type == types["PI Texture Dictionary"]:
+            self.read_pi_texture_dictionary(chunk)
+
+        self.rw_version = Sections.get_rw_version(chunk.version)
+
+    #######################################################
+    def clear(self):
+        self.native_textures = []
+        self.textures        = []
+        self.images          = []
+        self.pos             = 0
+        self.data            = ""
+        self.rw_version      = ""
+        self.device_id       = 0
+
+    #######################################################
+    def load_file(self, filename):
+
+        with open(filename, mode='rb') as file:
+            content = file.read()
+            self.load_memory(content)
+
+    #######################################################
+    def __init__(self):
+        self.clear()

--- a/gui/dff_ot.py
+++ b/gui/dff_ot.py
@@ -230,6 +230,13 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
         default     = False
     )
 
+    txd_filename :  bpy.props.StringProperty(
+        name        = "Custom TXD File Name",
+        description = "File name used for importing the TXD file. Leave blank if TXD name is same as DFF name",
+        maxlen      = 256,
+        default     = "",
+    )
+
     skip_mipmaps :  bpy.props.BoolProperty(
         name        = "Skip mipmaps",
         default     = True
@@ -289,6 +296,7 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
         box.prop(self, "load_txd")
         if self.load_txd:
             box.prop(self, "skip_mipmaps")
+            box.prop(self, "txd_filename", text="File name")
 
         layout.prop(self, "connect_bones")
         
@@ -325,7 +333,7 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
                     {
                         'file_name'      : file,
                         'load_txd'       : self.load_txd,
-                        'txd_file_name'  : '',
+                        'txd_filename'   : self.txd_filename,
                         'skip_mipmaps'   : self.skip_mipmaps,
                         'image_ext'      : image_ext,
                         'connect_bones'  : self.connect_bones,

--- a/gui/dff_ot.py
+++ b/gui/dff_ot.py
@@ -295,6 +295,7 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
                     {
                         'file_name'      : file,
                         'load_txd'       : self.load_txd,
+                        'txd_file_name'  : '',
                         'skip_mipmaps'   : self.skip_mipmaps,
                         'image_ext'      : image_ext,
                         'connect_bones'  : self.connect_bones,

--- a/gui/dff_ot.py
+++ b/gui/dff_ot.py
@@ -201,9 +201,13 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
          options     = {'HIDDEN'}
      )
 
-    
     load_txd :  bpy.props.BoolProperty(
         name        = "Load TXD file",
+        default     = False
+    )
+
+    skip_mipmaps :  bpy.props.BoolProperty(
+        name        = "Skip mipmaps",
         default     = True
     )
 
@@ -257,7 +261,11 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
     def draw(self, context):
         layout = self.layout
 
-        layout.prop(self, "load_txd")
+        box = layout.box()
+        box.prop(self, "load_txd")
+        if self.load_txd:
+            box.prop(self, "skip_mipmaps")
+
         layout.prop(self, "connect_bones")
         
         box = layout.box()
@@ -286,6 +294,8 @@ class IMPORT_OT_dff(bpy.types.Operator, ImportHelper):
                 importer = dff_importer.import_dff(
                     {
                         'file_name'      : file,
+                        'load_txd'       : self.load_txd,
+                        'skip_mipmaps'   : self.skip_mipmaps,
                         'image_ext'      : image_ext,
                         'connect_bones'  : self.connect_bones,
                         'use_mat_split'  : self.read_mat_split,

--- a/gui/map.py
+++ b/gui/map.py
@@ -30,6 +30,11 @@ class DFFSceneProps(bpy.types.PropertyGroup):
         default     = False
     )
 
+    load_txd: bpy.props.BoolProperty(
+        name        = "Load TXD files",
+        default     = False
+    )
+
     read_mat_split  :  bpy.props.BoolProperty(
         name        = "Read Material Split",
         description = "Whether to read material split for loading triangles",
@@ -87,6 +92,7 @@ class MapImportPanel(bpy.types.Panel):
         col.prop(settings, "map_sections", text="Map segment")
         col.separator()
         col.prop(settings, "skip_lod", text="Skip LOD objects")
+        col.prop(settings, "load_txd", text="Load TXD files")
         col.prop(settings, "read_mat_split", text="Read Material Split")
 
         layout.separator()

--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -65,7 +65,7 @@ class ext_2dfx_importer:
 class dff_importer:
 
     load_txd           = False
-    txd_file_name      = ""
+    txd_filename       = ""
     skip_mipmaps       = True
     image_ext          = "png"
     use_bone_connect   = False
@@ -820,8 +820,10 @@ class dff_importer:
         # Load the TXD
         if self.load_txd:
             # Import txd from a file if file exists
-            txd_path = self.txd_file_name if self.txd_file_name \
-                else file_name[:-4] + ".txd"
+            base_path = os.path.dirname(file_name)
+            txd_filename = self.txd_filename if self.txd_filename \
+                else os.path.basename(file_name)[:-4] + ".txd"
+            txd_path = os.path.join(base_path, txd_filename)
             if os.path.isfile(txd_path):
                 self.txd_images = txd_importer.import_txd(
                     {
@@ -860,7 +862,7 @@ def import_dff(options):
 
     # Shadow function
     dff_importer.load_txd         = options['load_txd']
-    dff_importer.txd_file_name    = options['txd_file_name']
+    dff_importer.txd_filename     = options['txd_filename']
     dff_importer.skip_mipmaps     = options['skip_mipmaps']
     dff_importer.image_ext        = options['image_ext']
     dff_importer.use_bone_connect = options['connect_bones']
@@ -871,5 +873,4 @@ def import_dff(options):
 
     dff_importer.import_dff(options['file_name'])
 
-    return dff_importer
     return dff_importer

--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -65,6 +65,7 @@ class ext_2dfx_importer:
 class dff_importer:
 
     load_txd           = False
+    txd_file_name      = ""
     skip_mipmaps       = True
     image_ext          = "png"
     use_bone_connect   = False
@@ -819,7 +820,8 @@ class dff_importer:
         # Load the TXD
         if self.load_txd:
             # Import txd from a file if file exists
-            txd_path = file_name[:-4] + ".txd"
+            txd_path = self.txd_file_name if self.txd_file_name \
+                else file_name[:-4] + ".txd"
             if os.path.isfile(txd_path):
                 self.txd_images = txd_importer.import_txd(
                     {
@@ -858,6 +860,7 @@ def import_dff(options):
 
     # Shadow function
     dff_importer.load_txd         = options['load_txd']
+    dff_importer.txd_file_name    = options['txd_file_name']
     dff_importer.skip_mipmaps     = options['skip_mipmaps']
     dff_importer.image_ext        = options['image_ext']
     dff_importer.use_bone_connect = options['connect_bones']

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -112,9 +112,7 @@ class Map_Import_Operator(bpy.types.Operator):
                         self.settings.dff_folder, model
                     ),
                     'load_txd'       : self.settings.load_txd,
-                    'txd_file_name'  : "%s/%s.txd" % (
-                        self.settings.dff_folder, txd
-                    ),
+                    'txd_filename'   : "%s.txd" % txd,
                     'skip_mipmaps'   : True,
                     'image_ext'      : 'PNG',
                     'connect_bones'  : False,

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -102,6 +102,8 @@ class Map_Import_Operator(bpy.types.Operator):
                     'file_name'      : "%s/%s.dff" % (
                         self.settings.dff_folder, model
                     ),
+                    'load_txd'       : False,
+                    'skip_mipmaps'   : False,
                     'image_ext'      : 'PNG',
                     'connect_bones'  : False,
                     'use_mat_split'  : self.settings.read_mat_split,

--- a/ops/map_importer.py
+++ b/ops/map_importer.py
@@ -57,6 +57,7 @@ class Map_Import_Operator(bpy.types.Operator):
             return
 
         model = self._object_data[inst.id].modelName
+        txd = self._object_data[inst.id].txdName
 
         if inst.id in self._model_cache:
 
@@ -102,8 +103,11 @@ class Map_Import_Operator(bpy.types.Operator):
                     'file_name'      : "%s/%s.dff" % (
                         self.settings.dff_folder, model
                     ),
-                    'load_txd'       : False,
-                    'skip_mipmaps'   : False,
+                    'load_txd'       : self.settings.load_txd,
+                    'txd_file_name'  : "%s/%s.txd" % (
+                        self.settings.dff_folder, txd
+                    ),
+                    'skip_mipmaps'   : True,
                     'image_ext'      : 'PNG',
                     'connect_bones'  : False,
                     'use_mat_split'  : self.settings.read_mat_split,

--- a/ops/txd_importer.py
+++ b/ops/txd_importer.py
@@ -1,0 +1,109 @@
+# GTA DragonFF - Blender scripts to edit basic GTA formats
+# Copyright (C) 2019  Parik
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import bpy
+import os
+
+from ..gtaLib import txd
+
+#######################################################
+class txd_importer:
+
+    skip_mipmaps = True
+
+    __slots__ = [
+        'txd',
+        'images',
+        'file_name'
+    ]
+
+    #######################################################
+    def _init():
+        self = txd_importer
+
+        # Variables
+        self.txd = None
+        self.images = {}
+        self.file_name = ""
+
+    #######################################################
+    def _create_image(name, rgba, width, height):
+        pixels = []
+        for h in range(height - 1, -1, -1):
+            offset = h * width * 4
+            pixels += list(map(lambda b: b / 0xff, rgba[offset:offset+width*4]))
+
+        image = bpy.data.images.new(name, width, height)
+        image.pixels = pixels
+
+        return image
+
+    #######################################################
+    def import_textures():
+        self = txd_importer
+
+        txd_name = os.path.basename(self.file_name)
+
+        # Import native textures
+        for tex in self.txd.native_textures:
+            images = []
+            num_levels = tex.num_levels if not self.skip_mipmaps else 1
+
+            for level in range(num_levels):
+                image_name = "%s/%s/%d" % (txd_name, tex.name, level)
+                image = txd_importer._create_image(image_name,
+                                                    tex.to_rgba(level),
+                                                    tex.get_width(level),
+                                                    tex.get_height(level))
+                images.append(image)
+
+            self.images[tex.name] = images
+
+        # Import textures
+        for tex, imgs in zip(self.txd.textures, self.txd.images):
+            images = []
+            num_levels = len(imgs) if not self.skip_mipmaps else 1
+
+            for level in range(num_levels):
+                img = imgs[level]
+                image_name = "%s/%s/%d" % (txd_name, tex.name, level)
+                image = txd_importer._create_image(image_name,
+                                                    img.to_rgba(),
+                                                    img.width,
+                                                    img.height)
+                images.append(image)
+
+            self.images[tex.name] = images
+
+    #######################################################
+    def import_txd(file_name):
+        self = txd_importer
+        self._init()
+
+        self.txd = txd.txd()
+        self.txd.load_file(file_name)
+        self.file_name = file_name
+
+        self.import_textures()
+
+#######################################################
+def import_txd(options):
+
+    txd_importer.skip_mipmaps = options['skip_mipmaps']
+
+    txd_importer.import_txd(options['file_name'])
+
+    return txd_importer

--- a/ops/txd_importer.py
+++ b/ops/txd_importer.py
@@ -64,10 +64,12 @@ class txd_importer:
 
             for level in range(num_levels):
                 image_name = "%s/%s/%d" % (txd_name, tex.name, level)
-                image = txd_importer._create_image(image_name,
-                                                    tex.to_rgba(level),
-                                                    tex.get_width(level),
-                                                    tex.get_height(level))
+                image = bpy.data.images.get(image_name)
+                if not image:
+                    image = txd_importer._create_image(image_name,
+                                                        tex.to_rgba(level),
+                                                        tex.get_width(level),
+                                                        tex.get_height(level))
                 images.append(image)
 
             self.images[tex.name] = images


### PR DESCRIPTION
Experimental feature

![image](https://github.com/Parik27/DragonFF/assets/31922454/a3a9331e-cd0a-42ec-978e-b58cf7703a12)

![image](https://github.com/Parik27/DragonFF/assets/31922454/6df6910c-5cc8-4cde-bdcc-49ec8756dd62)

TXD is imported according to the DFF file name. For example, if you enable the "Load TXD file" option when importing ```cop.dff```, the file ```cop.txd``` will be imported. If there is no such file, the “Scan for Images” option will be used.

