### PR TITLE
Small fixes to dff exporter

### DIFF
--- a/ops/col_exporter.py
+++ b/ops/col_exporter.py
@@ -255,7 +255,7 @@ class col_exporter:
 
         bounds_found = False
         objects = bpy.data.objects
-        if self.collection is not None:
+        if self.collection is not None and len(self.collection.objects) > 0:
             objects = self.collection.objects
             # Get original import bounds from collection (some collisions come in as just bounds with no other items)
             if self.collection.get('bounds min') and self.collection.get('bounds max'):

--- a/ops/dff_exporter.py
+++ b/ops/dff_exporter.py
@@ -918,11 +918,9 @@ class dff_exporter:
         
         for obj in objects:
 
-            # Skip collision objects in the base collection. These are inside their own nested collection for singularly
-            # imported DFFs, but the map importer will put collision meshes inside the same collection as the map mesh
-            # object they represent. We can just ignore collision meshes here as the DFF exporter will still look for
+            # We can just ignore collision meshes here as the DFF exporter will still look for
             # them in their own nested collection later if export_coll is true.
-            if obj.dff.type == 'COL':
+            if obj.dff.type == 'COL' or obj.dff.type == 'SHA':
                 continue
 
             # create atomic in this case
@@ -946,12 +944,15 @@ class dff_exporter:
             })
 
             if len(mem) != 0:
-               self.dff.collisions = [mem] 
+                self.dff.collisions = [mem]
 
         if name is None:
             self.dff.write_file(self.file_name, self.version )
         else:
-            self.dff.write_file("%s/%s" % (self.path, name), self.version)
+            filename = "%s/%s" % (self.path, name)
+            if not filename.endswith('.dff'):
+                filename += '.dff'
+            self.dff.write_file(filename, self.version)
 
     #######################################################
     @staticmethod
@@ -977,10 +978,7 @@ class dff_exporter:
             if self.from_outliner:
                 collections = [bpy.context.view_layer.objects.active.users_collection[0]]
             else:
-                collections = []
-                for collection in bpy.data.collections:
-                    if collection.name.lower().endswith(".dff"):
-                        collections.append(collection)
+                collections = [c for c in bpy.data.collections]
 
         for collection in collections:
             for obj in collection.objects:


### PR DESCRIPTION
Fixed a regression where meshes were skipped for export unless they resided in a collection named with ".dff" at the end. Also made the exporter ensure the correct file extension when doing a 'mass export' (files are named after their collection with that option enabled, but the collection may not have ".dff" at the end of its name). Also fixed a small bug where exporting with 'export collisions' enabled will throw an error if no collisions exist in the scene.