### PR TITLE
Support custom binary IPL importing

### DIFF
--- a/gtaLib/map.py
+++ b/gtaLib/map.py
@@ -150,6 +150,9 @@ class MapDataUtility:
     def readBinaryIPLFromStream(fileStream, dataStructures):
         sections = {}
         
+        # Save the starting position (where the IPL file begins)
+        start_pos = fileStream.tell()
+        
         # Read and unpack the header
         header = fileStream.read(32)
         if len(header) < 32:
@@ -161,7 +164,8 @@ class MapDataUtility:
         # Read and process instance definitions
         item_size = 40
         insts = []
-        fileStream.seek(instances_offset)
+        # Seek relative to the start of the IPL file
+        fileStream.seek(start_pos + instances_offset)
         
         for i in range(num_of_instances):
             instances = fileStream.read(40)

--- a/gtaLib/map.py
+++ b/gtaLib/map.py
@@ -139,7 +139,11 @@ class MapDataUtility:
     #######################################################
     def readFile(filepath, filename, dataStructures):
 
-        fullpath = "%s%s" % (filepath, filename)
+        # Check if filename is already an absolute path
+        if os.path.isabs(filename):
+            fullpath = filename
+        else:
+            fullpath = "%s%s" % (filepath, filename)
         print('\nMapDataUtility reading: ' + fullpath)
 
         sections = {}

--- a/gui/map.py
+++ b/gui/map.py
@@ -79,7 +79,7 @@ class DFFSceneProps(bpy.types.PropertyGroup):
     custom_ipl_path : bpy.props.StringProperty(
         name        = "IPL path",
         default     = '',
-        description = "Custom IPL path"
+        description = "Custom IPL path (supports both relative paths from game root and absolute paths)"
     )
 
     use_custom_map_section : bpy.props.BoolProperty(
@@ -274,10 +274,18 @@ class SCENE_OT_ipl_select(bpy.types.Operator, ImportHelper):
     def execute(self, context):
         if os.path.splitext(self.filepath)[-1].lower() == self.filename_ext:
             filepath = os.path.normpath(self.filepath)
+            # Try to find if the file is within the game directory structure
             sep_pos = filepath.upper().find(f"DATA{os.sep}MAPS")
-            game_root = filepath[:sep_pos]
-            context.scene.dff.game_root = game_root
-            context.scene.dff.custom_ipl_path = os.path.relpath(filepath, game_root)
+            
+            if sep_pos != -1:
+                # File is within game directory, use relative path
+                game_root = filepath[:sep_pos]
+                context.scene.dff.game_root = game_root
+                context.scene.dff.custom_ipl_path = os.path.relpath(filepath, game_root)
+            else:
+                # File is outside game directory, use absolute path
+                # Don't change game_root, keep the existing one
+                context.scene.dff.custom_ipl_path = filepath
         return {'FINISHED'}
 
 #######################################################


### PR DESCRIPTION
# The issue

Currently it isn't possible to import a binary IPL from a custom path.

I found this a bit troublesome for modding interiors whose IPLs are in `gta-int.img` instead of `gta3.img`.

There are two main limitations currently:
1. The IPL path is always treated as relative to the game directory - this may not be the case if you've extracted IPLs from an archive like you'd do alongside your DFFs
2. The map importer only supports reading binary IPLs from `gta3.img`, and only in the case that opening the file from disk failed.

# This PR

1. Allows absolute paths in the custom IPL path input
2. Updates `MapDataUtility` so that it guesses if it's a binary IPL based on the filename (ends in `_stream*.ipl`), and re-uses the binary IPL importer in this case.

# Preview

![Screenshot 2025-06-14 191407](https://github.com/user-attachments/assets/707ea9ee-1f72-45d6-9cf9-ee82a91932b8)
