### PR TITLE
Remove padding from frame names

### DIFF
--- a/gtaLib/dff.py
+++ b/gtaLib/dff.py
@@ -693,7 +693,8 @@ class Frame:
             data += self.user_data.to_mem()
 
         if self.name is not None and self.name != "unknown":
-            data += Sections.write_chunk(Sections.pad_string(self.name),
+            frame_name = self.name.encode("utf-8")
+            data += Sections.write_chunk(frame_name,
                                          types["Frame"])
 
         return Sections.write_chunk(data, types["Extension"])


### PR DESCRIPTION

III/Vice City
<img width="653" height="680" alt="image" src="https://github.com/user-attachments/assets/fc84cd80-fc26-4b93-b1eb-31d23411d09e" />

San Andreas: 

<img width="671" height="679" alt="image" src="https://github.com/user-attachments/assets/ee769c5d-6311-4fb7-8615-f94d937e6509" />

I wasn't sure if this was intentional, but the name of frames often contains no null/padding when it comes to III, Vice City, and San Andreas, which DragonFF currently does produce in the frame names. This doesn't really cause problems in-game, or re-importing into Blender, but it does cause problems for yourself or anyone else using your model in another 3d Modelling program such as 3DSMax, possibly even ZModeler(though, who uses that anymore). This commit tries to be more faithful to the frame name format by omitting any such padding and fixing the issue with importing into other 3D Modelling programs.

<img width="654" height="672" alt="image" src="https://github.com/user-attachments/assets/571543fc-bad0-4d13-9518-38ad5b7c514e" />
