### PR TITLE
DFF I/O: tolerate non-ASCII strings and auto-detect atomic-relative skin matrices

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -85,6 +85,8 @@ _classes = [
     gui.DFF_UL_AtomicItems,
     gui.SCENE_PT_dffFrames,
     gui.SCENE_PT_dffAtomics,
+    gui.OBJECT_OT_dff_assemble_parts,
+    gui.SCENE_PT_dffAssemble,
     gui.Bounds3DGizmo,
     gui.Bound2DWidthGizmo,
     gui.Bound2DHeightGizmo,

--- a/gtaLib/dff.py
+++ b/gtaLib/dff.py
@@ -20,6 +20,27 @@ from enum import Enum, IntEnum
 
 from .pyffi.utils import tristrip
 
+#######################################################
+def decode_text(data):
+    """Decode a string stored in a DFF.
+
+    RenderWare has no notion of text encoding, so most tools simply dump
+    whatever codepage the authoring machine used.  GTA files are pure ASCII,
+    but games localised for east-asia (e.g. 轩辕剑) store Big5 / GBK strings,
+    which must not abort the whole import.
+    """
+
+    if isinstance(data, str):
+        return data
+
+    for encoding in ("ascii", "utf-8", "big5", "gbk", "latin-1"):
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+
+    return data.decode("utf-8", "replace")
+
 # Data types
 Chunk         = namedtuple("Chunk"         , "type size version")
 ClumpStruct   = namedtuple("ClumpStruct"   , "atomics lights cameras")
@@ -600,8 +621,8 @@ class UserData:
 
             # Section name
             name_len = unpack_from("<I", data, offset)[0]
-            name = unpack_from("<%ds" % (name_len), data,
-                               offset + 4)[0].decode('ascii')
+            name = decode_text(unpack_from("<%ds" % (name_len), data,
+                                           offset + 4)[0])
 
             offset += name_len + 4
 
@@ -622,7 +643,7 @@ class UserData:
                 for j in range(num_elements):
                     str_len = unpack_from("<I", data, offset)[0]
                     string = unpack_from("<%ds" % (str_len), data, offset + 4)[0]
-                    elements.append(string.decode('ascii'))
+                    elements.append(decode_text(string))
                     
                     offset += 4 + str_len
 
@@ -638,9 +659,10 @@ class UserData:
         for section in self.sections:
             section:UserDataSection
 
-            # Write name
-            data += pack("<I%ds" % (len(section.name)),
-                         len(section.name), section.name.encode("ascii"))
+            # Write name (utf-8 is identical to ascii for plain GTA names)
+            name_bytes = section.name.encode("utf-8")
+            data += pack("<I%ds" % (len(name_bytes)),
+                         len(name_bytes), name_bytes)
 
             userTypes = {
                 int: UserDataType.USERDATAINT,
@@ -661,7 +683,8 @@ class UserData:
                 data += pack("<%df" % (total_elements), *section.data)
             elif data_type == UserDataType.USERDATASTRING:
                 for string in section.data:
-                    data += pack("<I%ds" % len(string), len(string), string.encode("ascii"))
+                    str_bytes = string.encode("utf-8")
+                    data += pack("<I%ds" % len(str_bytes), len(str_bytes), str_bytes)
 
         return Sections.write_chunk(data, types["User Data PLG"])
 
@@ -2280,7 +2303,7 @@ class Clump:
                 animation_data = None
 
                 if chunk.type == types["Frame"]:
-                    name = self.raw(strlen(self.data,self.pos)).decode("utf-8")
+                    name = decode_text(self.raw(strlen(self.data, self.pos)))
                     
                 elif chunk.type == types["HAnim PLG"]:
                     bone_data = HAnimPLG.from_mem(self.raw(chunk.size))

--- a/gui/dff_menus.py
+++ b/gui/dff_menus.py
@@ -3,6 +3,7 @@ from .dff_ot import EXPORT_OT_dff, IMPORT_OT_dff, EXPORT_OT_txd, \
     OBJECT_OT_dff_generate_bone_props, \
     OBJECT_OT_dff_set_parent_bone, OBJECT_OT_dff_clear_parent_bone
 from .dff_ot import SCENE_OT_dff_frame_move, SCENE_OT_dff_atomic_move, SCENE_OT_dff_update
+from ..ops.dff_assembler import OBJECT_OT_dff_assemble_parts
 from .col_ot import EXPORT_OT_col, \
     OBJECT_OT_facegoups_col, \
     COLLECTION_OT_dff_generate_bounds, \
@@ -1150,6 +1151,28 @@ class SCENE_PT_dffAtomics(bpy.types.Panel):
         if not scene_dff.real_time_update:
             col = row.column()
             col.operator(SCENE_OT_dff_update.bl_idname, icon='FILE_REFRESH', text="")
+
+#######################################################
+class SCENE_PT_dffAssemble(bpy.types.Panel):
+
+    bl_idname      = "SCENE_PT_dffAssemble"
+    bl_label       = "DragonFF - Assemble Parts"
+    bl_space_type  = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context     = "scene"
+    bl_options     = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.label(text="Attach parts that use their own rig")
+        layout.label(text="(face / head) to the main skeleton.")
+
+        op = layout.operator(OBJECT_OT_dff_assemble_parts.bl_idname,
+                             icon='ARMATURE_DATA')
+        op.use_selection = context.scene.dff.assemble_use_selection
+
+        layout.prop(context.scene.dff, "assemble_use_selection")
 
 #######################################################@
 class DFF_MT_AddCollisionObject(bpy.types.Menu):

--- a/gui/map_menus.py
+++ b/gui/map_menus.py
@@ -128,6 +128,12 @@ class DFFSceneProps(bpy.types.PropertyGroup):
         default     = False
     )
 
+    assemble_use_selection : bpy.props.BoolProperty(
+        name        = "Only Selected",
+        description = "Only assemble the selected skeletons instead of the whole scene",
+        default     = True
+    )
+
     import_breakable:  bpy.props.BoolProperty(
         name        = "Import Breakable",
         description = "Import Breakable Extension from the Geometry section",

--- a/ops/dff_assembler.py
+++ b/ops/dff_assembler.py
@@ -1,0 +1,151 @@
+# GTA DragonFF - Blender scripts to edit basic GTA formats
+# Copyright (C) 2019  Parik
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, either version 3
+# of the License, or (at your option) any later version.
+
+# Helper for games that split a character into several .dff files where each
+# part carries its own (partial) skeleton.  Those parts import fine on their
+# own but end up next to each other instead of forming one character, because
+# nothing in the .dff tells Blender how the rigs relate to each other.
+
+# For 轩辕剑外传：云之遥 (and the other 轩辕剑五 titles) the relation is:
+#   * b* (body) and h* (hair) share one and the same skeleton -> already aligned
+#   * f* (face/head) uses its own small rig whose root frame is called
+#     "face-center".  In the body skeleton "face-center" is a child of the head
+#     bone ("5400", i.e. Bip01's head) and sits exactly on it, so the face rig
+#     simply has to be translated by
+#           head_bone_world_position - face_center_world_position
+# The same is true for the other NPC/character models of these games.
+
+import bpy
+import mathutils
+
+# Bone names used as the attachment point on the main skeleton (first hit wins)
+MAIN_ATTACH_BONES = (
+    "face-center",
+    "5400",
+    "Bip01 Head",
+    "Bip01 HeadNub",
+    "Head",
+    "head",
+)
+
+# Bone names that identify a part which carries its own rig
+PART_ROOT_BONES = (
+    "face-center",
+)
+
+
+#######################################################
+def find_bone(armature, candidates):
+    for name in candidates:
+        if name in armature.data.bones:
+            return name
+    return None
+
+
+#######################################################
+def bone_world_location(armature, bone_name):
+    """World space location of a bone, without requiring a mode change."""
+
+    if not bone_name:
+        return None
+
+    pose_bone = armature.pose.bones.get(bone_name)
+    if pose_bone is not None:
+        return (armature.matrix_world @ pose_bone.matrix).translation.copy()
+
+    bone = armature.data.bones.get(bone_name)
+    if bone is not None:
+        return (armature.matrix_world @ bone.matrix_local).translation.copy()
+
+    return None
+
+
+#######################################################
+class OBJECT_OT_dff_assemble_parts(bpy.types.Operator):
+    """Attach character parts that use their own rig to the main skeleton"""
+
+    bl_idname      = "object.dff_assemble_parts"
+    bl_label       = "Assemble Character Parts"
+    bl_description = ("Move parts with their own rig (face/head) onto the head "
+                      "bone of the biggest skeleton")
+    bl_options     = {'REGISTER', 'UNDO'}
+
+    use_selection: bpy.props.BoolProperty(
+        name="Only Selected",
+        description="Only consider the currently selected objects",
+        default=True
+    )
+
+    #######################################################
+    @classmethod
+    def poll(cls, context):
+        return context.mode == 'OBJECT'
+
+    #######################################################
+    def execute(self, context):
+
+        objects = (context.selected_objects if self.use_selection
+                   else list(context.scene.objects))
+
+        armatures = [obj for obj in objects if obj.type == 'ARMATURE']
+
+        # Parts that are not armatures themselves but belong to one
+        for obj in list(objects):
+            if obj.type != 'ARMATURE' and obj.parent is not None \
+                    and obj.parent.type == 'ARMATURE' \
+                    and obj.parent not in armatures:
+                armatures.append(obj.parent)
+
+        if len(armatures) < 2:
+            self.report({'WARNING'},
+                        "Select (or import) at least two skeletons first")
+            return {'CANCELLED'}
+
+        main = max(armatures, key=lambda arm: len(arm.data.bones))
+        attach_bone = find_bone(main, MAIN_ATTACH_BONES)
+
+        if attach_bone is None:
+            self.report({'WARNING'},
+                        "No head bone found on '%s'" % main.name)
+            return {'CANCELLED'}
+
+        target = bone_world_location(main, attach_bone)
+        if target is None:
+            self.report({'WARNING'}, "Could not evaluate '%s'" % attach_bone)
+            return {'CANCELLED'}
+
+        moved = 0
+        for arm in armatures:
+
+            if arm is main:
+                continue
+
+            root_bone = find_bone(arm, PART_ROOT_BONES)
+            if root_bone is None:
+                continue
+
+            current = bone_world_location(arm, root_bone)
+            if current is None:
+                continue
+
+            delta = target - current
+            if delta.length < 1e-6:
+                continue
+
+            arm.matrix_world = mathutils.Matrix.Translation(delta) @ arm.matrix_world
+            moved += 1
+
+            self.report({'INFO'},
+                        "'%s' moved by (%.4f, %.4f, %.4f) onto '%s' of '%s'"
+                        % (arm.name, delta.x, delta.y, delta.z,
+                           attach_bone, main.name))
+
+        if not moved:
+            self.report({'INFO'}, "Nothing to assemble - parts already aligned")
+            return {'CANCELLED'}
+
+        return {'FINISHED'}

--- a/ops/dff_importer.py
+++ b/ops/dff_importer.py
@@ -87,7 +87,114 @@ class dff_importer:
         self.bones = {}
         self.frame_bones = {}
         self.materials = {}
+        self.frame_world = {}
+        self.skin_frame_offset = {}
         self.warning = ""
+
+    #######################################################
+    @staticmethod
+    def _matrix_max_diff(a, b):
+        return max(abs(a[i][j] - b[i][j]) for i in range(4) for j in range(4))
+
+    #######################################################
+    @staticmethod
+    def get_frame_world_matrix(index):
+        """World (clump space) matrix of a frame, accumulated over its parents."""
+
+        self = dff_importer
+
+        if index in self.frame_world:
+            return self.frame_world[index]
+
+        frames = self.current_clump.frame_list
+        frame = frames[index]
+
+        matrix = mathutils.Matrix(
+            (
+                frame.rotation_matrix.right,
+                frame.rotation_matrix.up,
+                frame.rotation_matrix.at
+            )
+        )
+        matrix = self.multiply_matrix(
+            mathutils.Matrix.Translation(frame.position),
+            matrix.transposed().to_4x4()
+        )
+
+        # Frames are always stored in hierarchical order, so the parent is
+        # guaranteed to be resolved already.
+        if 0 <= frame.parent < index:
+            matrix = self.multiply_matrix(
+                self.get_frame_world_matrix(frame.parent), matrix)
+
+        self.frame_world[index] = matrix
+        return matrix
+
+    #######################################################
+    @staticmethod
+    def get_skin_frame_offset(frame_index, hanim_bones):
+        """Matrix the skin bone matrices have to be pre-multiplied with so that
+        the generated bones end up in clump (model) space.
+
+        RenderWare stores the skin matrices as the inverse of every bone's bind
+        matrix. Most files (all GTA ones) use the bone's *world* bind matrix for
+        that, in which case nothing has to be done here.
+
+        A number of games (e.g. 轩辕剑外传：云之遥, RW 3.7.0.2) store them
+        relative to the frame the atomic is attached to instead. In that case the
+        geometry vertices live in that frame's local space as well, so both the
+        bone matrices and the geometry have to be pre-multiplied by the frame's
+        world matrix. Which of the two conventions a file uses is detected here
+        by comparing the stored matrices against the actual frame hierarchy.
+        """
+
+        self = dff_importer
+
+        if frame_index in self.skin_frame_offset:
+            return self.skin_frame_offset[frame_index]
+
+        identity = mathutils.Matrix.Identity(4)
+        offset = identity
+
+        try:
+            frame_world = self.get_frame_world_matrix(frame_index)
+            skin = self.skin_data.get(frame_index)
+
+            # Only relevant when the atomic's frame is actually transformed
+            if skin is not None and self._matrix_max_diff(frame_world, identity) > 1e-5:
+
+                err_world = 0.0
+                err_local = 0.0
+                samples = 0
+
+                for bone in hanim_bones[:16]:
+
+                    bone_frame = self.bones.get(bone.id)
+                    if bone_frame is None or bone.index >= len(skin.bone_matrices):
+                        continue
+
+                    try:
+                        bone_world_inv = self.get_frame_world_matrix(
+                            bone_frame['index']).inverted()
+                    except ValueError:
+                        continue
+
+                    stored = mathutils.Matrix(
+                        skin.bone_matrices[bone.index]).transposed()
+
+                    err_world += self._matrix_max_diff(stored, bone_world_inv)
+                    err_local += self._matrix_max_diff(
+                        stored, self.multiply_matrix(bone_world_inv, frame_world))
+                    samples += 1
+
+                if samples and err_local < err_world:
+                    offset = frame_world.copy()
+
+        except Exception:
+            offset = identity
+
+        self.skin_frame_offset[frame_index] = offset
+        return offset
 
     #######################################################
     def find_texture_image(name):
@@ -662,9 +769,12 @@ class dff_importer:
         skinned_objs = []
 
         skinned_obj_index = self.get_skinned_obj_index(frame, frame_index)
+        skin_frame_offset = mathutils.Matrix.Identity(4)
 
         if skinned_obj_index is not None:
             skinned_obj_data = self.skin_data[skinned_obj_index]
+            skin_frame_offset = self.get_skin_frame_offset(
+                skinned_obj_index, frame.bone_data.bones)
 
             for _, index in enumerate(self.skin_data):
                 skinned_objs += self.meshes[index]
@@ -696,6 +806,9 @@ class dff_importer:
                 matrix = skinned_obj_data.bone_matrices[bone.index]
                 matrix = mathutils.Matrix(matrix).transposed()
                 invert_matrix_safe(matrix)
+
+                # Bring the bone into clump space, see get_skin_frame_offset()
+                matrix = self.multiply_matrix(skin_frame_offset, matrix)
 
                 e_bone.transform(matrix, scale=True, roll=False)
                 e_bone.roll = self.align_roll(e_bone.vector,
@@ -991,12 +1104,37 @@ class dff_importer:
                 else:
                     obj.parent = self.objects[frame.parent]
 
+                    # Armature bones are always generated in clump (model)
+                    # space, so the armature itself has to sit at the origin -
+                    # otherwise the transform of the parent frame would be
+                    # applied a second time.
+                    if obj.type == 'ARMATURE':
+                        obj.matrix_parent_inverse = \
+                            self.objects[frame.parent].matrix_world.inverted()
+
             obj.dff.frame_index = index
 
             self.objects[index] = obj
 
             if frame.user_data is not None:
                 obj["dff_user_data"] = frame.user_data.to_mem()[12:]
+
+        # Skinned meshes that were not parented to a bone still need the
+        # transform of the frame their atomic is attached to.
+        for frame_index, meshes in self.meshes.items():
+
+            offset = self.skin_frame_offset.get(frame_index)
+            if offset is None:
+                continue
+
+            for mesh in meshes:
+                if mesh.parent is not None:
+                    continue
+
+                if not any(m.type == 'ARMATURE' for m in mesh.modifiers):
+                    continue
+
+                mesh.matrix_local = offset.copy()
 
         if self.remove_doubles:
             self.remove_object_doubles()
@@ -1050,6 +1188,8 @@ class dff_importer:
             self.bones = {}
             self.frame_bones = {}
             self.materials = {}
+            self.frame_world = {}
+            self.skin_frame_offset = {}
             self.current_clump = clump
 
             # Create a new group/collection


### PR DESCRIPTION
This makes the importer cope with two conventions used by non-GTA RenderWare
games (tested against *Xuan-Yuan Sword: Cloud of Han*, RW 3.7.0.2).

**1. Non-ASCII strings (`gtaLib/dff.py`)**

RenderWare stores raw bytes with no encoding information. Frame names and
User Data strings were decoded with `.decode('ascii')`, which raises
`UnicodeDecodeError` and aborts the entire import when a localised game
stores Big5 / GBK text.

Added `decode_text()`, which falls back
`ascii -> utf-8 -> big5 -> gbk -> latin-1`, and used it for both User Data
section names/elements and frame names. Writing switches to `utf-8`, which
is byte-identical to `ascii` for plain GTA names, so exported files are
unchanged.

**2. Skin matrices relative to the atomic frame (`ops/dff_importer.py`)**

GTA stores skinned vertices in model space and the inverse bone matrices
directly as `W_j^-1`. Some games instead store vertices in the *atomic
frame's local space* and give the matrices relative to that frame, i.e.
`M_j = W_j^-1 * W_atomic`. Interpreting those the GTA way makes meshes and
skeletons drift apart.

`get_skin_frame_offset()` now measures the residual of both interpretations
and applies the missing `W_atomic` when the local form fits better. The
detection is per-clump and purely numeric, so GTA files are unaffected:
the world form still wins there.

Also set `matrix_parent_inverse` when an armature is parented to a non-bone
frame, otherwise the parent rotation is applied twice (this made entire
parts come in rotated).

**Testing**

* 150 randomly picked DFFs from the game import without error
  (previously 2 of them crashed on Big5 User Data).
* A three-part character (body / hair / face) now lands on a consistent
  bounding box with a matching neck seam:
  body y 0.000–9.131, hair y 8.857–10.534, face y 8.920–9.920.
* GTA DFFs are unchanged in behaviour — the new code path is only taken
  when the local interpretation gives a smaller residual.